### PR TITLE
Allow empty bonus, salesFrequency, dateAdded, sort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 
 php:
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
-dist: trusty
 
 php:
   - 5.6
   - 7.0
-  - hhvm
+  - 7.1
 
 install: composer install
 script: phpunit --configuration phpunit.xml --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "findologic/libflexport",
     "description": "FINDOLOGIC export toolkit for XML and CSV data export",
+    "version": "0.0.2",
     "require-dev": {
         "phpunit/phpunit": "~5.6",
         "goetas-webservices/xsd2php":"^0.2"

--- a/src/FINDOLOGIC/Export/Data/Item.php
+++ b/src/FINDOLOGIC/Export/Data/Item.php
@@ -56,6 +56,10 @@ abstract class Item implements Serializable
 
         $this->keywords = new AllKeywords();
         $this->ordernumbers = new AllOrdernumbers();
+        $this->bonus = new Bonus();
+        $this->salesFrequency = new SalesFrequency();
+        $this->dateAdded = new DateAdded();
+        $this->sort = new Sort();
     }
 
     public function setName(Name $name)

--- a/tests/FINDOLOGIC/Tests/XmlSerializationTest.php
+++ b/tests/FINDOLOGIC/Tests/XmlSerializationTest.php
@@ -76,22 +76,6 @@ class XmlSerializationTest extends TestCase
         $url->setValue('http://example.org/my-awesome-product.html');
         $item->setUrl($url);
 
-        $bonus = new Bonus();
-        $bonus->setValue(3);
-        $item->setBonus($bonus);
-
-        $salesFrequency = new SalesFrequency();
-        $salesFrequency->setValue(42);
-        $item->setSalesFrequency($salesFrequency);
-
-        $dateAdded = new DateAdded();
-        $dateAdded->setDateValue(new \DateTime());
-        $item->setDateAdded($dateAdded);
-
-        $sort = new Sort();
-        $sort->setValue(2);
-        $item->setSort($sort);
-
         return $item;
     }
 


### PR DESCRIPTION
This is required by the schema, so the library must cover it as well.

Fixes #1.