### PR TITLE
Allow setting simple values more efficiently

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,20 @@ Using the XML export is recommended by FINDOLOGIC. The XML is easier to read and
 ```php
 require_once './vendor/autoload.php';
 
-use \FINDOLOGIC\Export\XML\XMLExporter;
+use \FINDOLOGIC\Export\Exporter;
 use \FINDOLOGIC\Export\Data\Price;
 
 $exporter = Exporter::create(Exporter::TYPE_XML);
 
 $item = $exporter->createItem('123');
 
-$price = new Price();
-$price->setValue('13.37');
-$item->setPrice($price);
+$item->addPrice(13.37);
+// Alternative long form:
+// $price = new Price();
+// $price->setValue(13.37);
+// $item->setPrice($price);
 
-$exporter->serializeItems([$item], 0, 1);
+$exporter->serializeItems([$item], 0, 1, 1);
 ```
 
 ## Contributors

--- a/examples/XmlExample.php
+++ b/examples/XmlExample.php
@@ -3,13 +3,13 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 
 use FINDOLOGIC\Export\Data\Item;
-use \FINDOLOGIC\Export\Exporter;
-use \FINDOLOGIC\Export\Data\Ordernumber;
-use \FINDOLOGIC\Export\Data\Image;
-use \FINDOLOGIC\Export\Data\Attribute;
-use \FINDOLOGIC\Export\Data\Keyword;
-use \FINDOLOGIC\Export\Data\Usergroup;
-use \FINDOLOGIC\Export\Data\Property;
+use FINDOLOGIC\Export\Exporter;
+use FINDOLOGIC\Export\Data\Ordernumber;
+use FINDOLOGIC\Export\Data\Image;
+use FINDOLOGIC\Export\Data\Attribute;
+use FINDOLOGIC\Export\Data\Keyword;
+use FINDOLOGIC\Export\Data\Usergroup;
+use FINDOLOGIC\Export\Data\Property;
 
 /**
  * This example class builds a xml export based on the example of the FINDOLOGIC documentation, which can be found
@@ -86,8 +86,8 @@ class XmlExample
 
     private function addDateAddeds(Item $item, $itemData)
     {
-        $item->addDateAdded(new DateTime());
-        $item->addDateAdded(new DateTime(), 'LNrLF7BRVJ0toQ==');
+        $item->addDateAdded(new \DateTime());
+        $item->addDateAdded(new \DateTime(), 'LNrLF7BRVJ0toQ==');
     }
 
     private function addDescriptions(Item $item, $itemData)
@@ -95,7 +95,8 @@ class XmlExample
         $item->addDescription('With this sneaker you will walk in style. It\'s available in green and blue.');
         $item->addDescription(
             'With this men\'s sneaker you will walk in style. It\'s comes in various sizes and colors.',
-            'LNrLF7BRVJ0toQ==');
+            'LNrLF7BRVJ0toQ=='
+        );
     }
 
     private function addOrdernumbers(Item $item, $itemData)

--- a/examples/XmlExample.php
+++ b/examples/XmlExample.php
@@ -1,22 +1,14 @@
 <?php
 
-require_once '../vendor/autoload.php';
+require_once __DIR__ . '/../vendor/autoload.php';
 
+use FINDOLOGIC\Export\Data\Item;
 use \FINDOLOGIC\Export\Exporter;
 use \FINDOLOGIC\Export\Data\Ordernumber;
-use \FINDOLOGIC\Export\Data\Name;
-use \FINDOLOGIC\Export\Data\Summary;
-use \FINDOLOGIC\Export\Data\Description;
-use \FINDOLOGIC\Export\Data\Price;
-use \FINDOLOGIC\Export\Data\Url;
 use \FINDOLOGIC\Export\Data\Image;
 use \FINDOLOGIC\Export\Data\Attribute;
 use \FINDOLOGIC\Export\Data\Keyword;
 use \FINDOLOGIC\Export\Data\Usergroup;
-use \FINDOLOGIC\Export\Data\Bonus;
-use \FINDOLOGIC\Export\Data\SalesFrequency;
-use \FINDOLOGIC\Export\Data\DateAdded;
-use \FINDOLOGIC\Export\Data\Sort;
 use \FINDOLOGIC\Export\Data\Property;
 
 /**
@@ -59,7 +51,7 @@ class XmlExample
         return $exporter->serializeItems($itemsToExport, 0, 1, 1);
     }
 
-    private function addAttributes($item, $itemData)
+    private function addAttributes(Item $item, $itemData)
     {
         $attributesData = [
             'cat' => [
@@ -86,73 +78,27 @@ class XmlExample
         }
     }
 
-    private function addBonuses($item, $itemData)
+    private function addBonuses(Item $item, $itemData)
     {
-        $bonusesData = [
-            '' => [
-                3
-            ],
-            'LNrLF7BRVJ0toQ==' => [
-                5
-            ]
-        ];
-
-        $bonusElement = new Bonus();
-
-        foreach ($bonusesData as $usergroup => $bonuses) {
-            foreach ($bonuses as $bonus) {
-                $bonusElement->setValue($bonus, $usergroup);
-            }
-        }
-
-        $item->setBonus($bonusElement);
+        $item->addBonus(3);
+        $item->addBonus(5, 'LNrLF7BRVJ0toQ==');
     }
 
-    private function addDateAddeds($item, $itemData)
+    private function addDateAddeds(Item $item, $itemData)
     {
-        $dateAddedsData = [
-            '' => [
-                new \DateTime()
-            ],
-            'LNrLF7BRVJ0toQ==' => [
-                new \DateTime()
-            ]
-        ];
-
-        $dateAddedElement = new DateAdded();
-
-        foreach ($dateAddedsData as $usergroup => $dateAddeds) {
-            foreach ($dateAddeds as $dateAdded) {
-                $dateAddedElement->setDateValue($dateAdded, $usergroup);
-            }
-        }
-
-        $item->setDateAdded($dateAddedElement);
+        $item->addDateAdded(new DateTime());
+        $item->addDateAdded(new DateTime(), 'LNrLF7BRVJ0toQ==');
     }
 
-    private function addDescriptions($item, $itemData)
+    private function addDescriptions(Item $item, $itemData)
     {
-        $descriptionsData = [
-            '' => [
-                'With this sneaker you will walk in style. It\'s available in green and blue.'
-            ],
-            'LNrLF7BRVJ0toQ==' => [
-                'With this men\'s sneaker you will walk in style. It\'s comes in various sizes and colors.'
-            ]
-        ];
-
-        $descriptionElement = new Description();
-
-        foreach ($descriptionsData as $usergroup => $descriptions) {
-            foreach ($descriptions as $description) {
-                $descriptionElement->setValue($description, $usergroup);
-            }
-        }
-
-        $item->setDescription($descriptionElement);
+        $item->addDescription('With this sneaker you will walk in style. It\'s available in green and blue.');
+        $item->addDescription(
+            'With this men\'s sneaker you will walk in style. It\'s comes in various sizes and colors.',
+            'LNrLF7BRVJ0toQ==');
     }
 
-    private function addOrdernumbers($item, $itemData)
+    private function addOrdernumbers(Item $item, $itemData)
     {
         $ordernumbersData = [
             '' => [
@@ -171,7 +117,7 @@ class XmlExample
         }
     }
 
-    private function addImages($item, $itemData)
+    private function addImages(Item $item, $itemData)
     {
         $imagesData = [
             '' => [
@@ -191,7 +137,7 @@ class XmlExample
         }
     }
 
-    private function addKeywords($item, $itemData)
+    private function addKeywords(Item $item, $itemData)
     {
         $keywordsData = [
             '' => [
@@ -210,51 +156,19 @@ class XmlExample
         }
     }
 
-    private function addNames($item, $itemData)
+    private function addNames(Item $item, $itemData)
     {
-        $namesData = [
-            '' => [
-                'Adidas Sneaker'
-            ],
-            'LNrLF7BRVJ0toQ==' => [
-                'Adidas Men\'s Sneaker'
-            ]
-        ];
-
-        $nameElement = new Name();
-
-        foreach ($namesData as $usergroup => $names) {
-            foreach ($names as $name) {
-                $nameElement->setValue($name, $usergroup);
-            }
-        }
-
-        $item->setName($nameElement);
+        $item->addName('Adidas Sneaker');
+        $item->addName('Adidas Men\'s Sneaker', 'LNrLF7BRVJ0toQ==');
     }
 
-    private function addPrices($item, $itemData)
+    private function addPrices(Item $item, $itemData)
     {
-        $pricesData = [
-            '' => [
-                44.8
-            ],
-            'LNrLF7BRVJ0toQ==' => [
-                45.9
-            ]
-        ];
-
-        $priceElement = new Price();
-
-        foreach ($pricesData as $usergroup => $prices) {
-            foreach ($prices as $price) {
-                $priceElement->setValue($price, $usergroup);
-            }
-        }
-
-        $item->setPrice($priceElement);
+        $item->addPrice(44.8);
+        $item->addPrice(45.9, 'LNrLF7BRVJ0toQ==');
     }
 
-    private function addProperties($item, $itemData)
+    private function addProperties(Item $item, $itemData)
     {
         $propertiesData = [
             'sale' => [
@@ -289,95 +203,31 @@ class XmlExample
         }
     }
 
-    private function addSalesFrequencies($item, $itemData)
+    private function addSalesFrequencies(Item $item, $itemData)
     {
-        $salesFrequenciesData = [
-            '' => [
-                5
-            ],
-            'LNrLF7BRVJ0toQ==' => [
-                5
-            ]
-        ];
-
-        $salesFrequencyElement = new SalesFrequency();
-
-        foreach ($salesFrequenciesData as $usergroup => $salesFrequencies) {
-            foreach ($salesFrequencies as $salesFrequency) {
-                $salesFrequencyElement->setValue($salesFrequency, $usergroup);
-            }
-        }
-
-        $item->setSalesFrequency($salesFrequencyElement);
+        $item->addSalesFrequency(5);
+        $item->addSalesFrequency(10, 'LNrLF7BRVJ0toQ==');
     }
 
-    private function addSorts($item, $itemData)
+    private function addSorts(Item $item, $itemData)
     {
-        $sortsData = [
-            '' => [
-                5
-            ],
-            'LNrLF7BRVJ0toQ==' => [
-                7
-            ]
-        ];
-
-        $sortElement = new Sort();
-
-        foreach ($sortsData as $usergroup => $sorts) {
-            foreach ($sorts as $sort) {
-                $sortElement->setValue($sort, $usergroup);
-            }
-        }
-
-        $item->setSort($sortElement);
+        $item->addSort(5);
+        $item->addSort(7, 'LNrLF7BRVJ0toQ==');
     }
 
-    private function addSummaries($item, $itemData)
+    private function addSummaries(Item $item, $itemData)
     {
-        $summariesData = [
-            '' => [
-                'A cool and fashionable sneaker'
-            ],
-            'LNrLF7BRVJ0toQ==' => [
-                'A cool and fashionable sneaker for men'
-            ]
-        ];
-
-        $summaryElement = new Summary();
-
-        foreach ($summariesData as $usergroup => $summaries) {
-            foreach ($summaries as $summary) {
-                $summaryElement->setValue($summary, $usergroup);
-            }
-        }
-
-        $item->setSummary($summaryElement);
+        $item->addSummary('A cool and fashionable sneaker');
+        $item->addSummary('A cool and fashionable sneaker for men', 'LNrLF7BRVJ0toQ==');
     }
 
-    private function addUrls($item, $itemData)
+    private function addUrls(Item $item, $itemData)
     {
-        $urlsData = [
-            '' => [
-                'https://www.store.com/sneakers/adidas.html'
-            ],
-            'LNrLF7BRVJ0toQ==' => [
-                'https://www.store.com/sneakers/mens/adidas.html'
-            ]
-        ];
-
-        $urlElement = new Url();
-
-        foreach ($urlsData as $usergroup => $urls) {
-            foreach ($urls as $url) {
-                $urlElement->setValue($url, $usergroup);
-            }
-        }
-
-        $item->setUrl($urlElement);
+        $item->addUrl('https://www.store.com/sneakers/adidas.html');
+        $item->addUrl('https://www.store.com/sneakers/mens/adidas.html', 'LNrLF7BRVJ0toQ==');
     }
 
-    private function addUsergroups($item, $itemData)
+    private function addUsergroups(Item $item, $itemData)
     {
         $usergroups = [
             'LNrLF7BRVJ0toQ==',

--- a/src/FINDOLOGIC/Export/Data/DateAdded.php
+++ b/src/FINDOLOGIC/Export/Data/DateAdded.php
@@ -2,6 +2,7 @@
 
 namespace FINDOLOGIC\Export\Data;
 
+use DateTime;
 use FINDOLOGIC\Export\Helpers\UsergroupAwareSimpleValue;
 
 class DateAdded extends UsergroupAwareSimpleValue
@@ -16,9 +17,9 @@ class DateAdded extends UsergroupAwareSimpleValue
         throw new \BadMethodCallException('Assign DateAdded values by passing a \DateTime to setDateValue()');
     }
 
-    public function setDateValue(\DateTime $value, $usergroup = '')
+    public function setDateValue(DateTime $value, $usergroup = '')
     {
-        $formatted = $value->format(\DateTime::ATOM);
+        $formatted = $value->format(DateTime::ATOM);
 
         parent::setValue($formatted, $usergroup);
     }

--- a/src/FINDOLOGIC/Export/Data/Item.php
+++ b/src/FINDOLOGIC/Export/Data/Item.php
@@ -2,6 +2,7 @@
 
 namespace FINDOLOGIC\Export\Data;
 
+use DateTime;
 use FINDOLOGIC\Export\Helpers\Serializable;
 
 abstract class Item implements Serializable
@@ -65,9 +66,24 @@ abstract class Item implements Serializable
         $this->ordernumbers = new AllOrdernumbers();
     }
 
+    public function getName()
+    {
+        return $this->name;
+    }
+
     public function setName(Name $name)
     {
         $this->name = $name;
+    }
+
+    public function addName($name, $usergroup = '')
+    {
+        $this->name->setValue($name, $usergroup);
+    }
+
+    public function getSummary()
+    {
+        return $this->summary;
     }
 
     public function setSummary(Summary $summary)
@@ -75,9 +91,29 @@ abstract class Item implements Serializable
         $this->summary = $summary;
     }
 
+    public function addSummary($summary, $usergroup = '')
+    {
+        $this->summary->setValue($summary, $usergroup);
+    }
+
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
     public function setDescription(Description $description)
     {
         $this->description = $description;
+    }
+
+    public function addDescription($description, $usergroup = '')
+    {
+        $this->description->setValue($description, $usergroup);
+    }
+
+    public function getPrice()
+    {
+        return $this->price;
     }
 
     public function setPrice(Price $price)
@@ -85,9 +121,33 @@ abstract class Item implements Serializable
         $this->price = $price;
     }
 
+    public function addPrice($price, $usergroup = '')
+    {
+        if ($this->price === null) {
+            $this->price = new Price();
+        }
+
+        $this->price->setValue($price, $usergroup);
+    }
+
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
     public function setUrl(Url $url)
     {
         $this->url = $url;
+    }
+
+    public function addUrl($url, $usergroup = '')
+    {
+        $this->url->setValue($url, $usergroup);
+    }
+
+    public function getBonus()
+    {
+        return $this->bonus;
     }
 
     public function setBonus(Bonus $bonus)
@@ -95,9 +155,29 @@ abstract class Item implements Serializable
         $this->bonus = $bonus;
     }
 
+    public function addBonus($bonus, $usergroup = '')
+    {
+        $this->bonus->setValue($bonus, $usergroup);
+    }
+
+    public function getSalesFrequency()
+    {
+        return $this->salesFrequency;
+    }
+
     public function setSalesFrequency(SalesFrequency $salesFrequency)
     {
         $this->salesFrequency = $salesFrequency;
+    }
+
+    public function addSalesFrequency($salesFrequency, $usergroup = '')
+    {
+        $this->salesFrequency->setValue($salesFrequency, $usergroup);
+    }
+
+    public function getDateAdded()
+    {
+        return $this->dateAdded;
     }
 
     public function setDateAdded(DateAdded $dateAdded)
@@ -105,9 +185,24 @@ abstract class Item implements Serializable
         $this->dateAdded = $dateAdded;
     }
 
+    public function addDateAdded(DateTime $dateAdded, $usergroup = '')
+    {
+        $this->dateAdded->setDateValue($dateAdded, $usergroup);
+    }
+
+    public function getSort()
+    {
+        return $this->sort;
+    }
+
     public function setSort(Sort $sort)
     {
         $this->sort = $sort;
+    }
+
+    public function addSort($sort, $usergroup = '')
+    {
+        $this->sort->setValue($sort, $usergroup);
     }
 
     public function addProperty(Property $property)


### PR DESCRIPTION
Fixes #39.

Simples values, i.e. values other than properties, attributes, images
and usergroups, can now be set using a `Item::add<value>($value,
$usergroup = '')` method.

The corresponding `Item::set<value>(...)` methods still exist, so
compatibility is retained. However, this change should increment the
minor version number because functionality is added.