### PR TITLE
Add build matrix to check testsuite with newer phpunit version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,20 @@ php:
   - 7.2
 
 env:
-  - PATH=$PATH:vendor/bin
+  matrix:
+    - PHPUNIT_VERSION="5.6"
+    - PHPUNIT_VERSION="6.5"
+  global:
+    - PATH=$PATH:vendor/bin
 
-install: composer install
+matrix:
+  exclude:
+  - php: 5.6
+    env: PHPUNIT_VERSION="6.5"
+
+install:
+  - if [[ "$PHPUNIT_VERSION" = "6.5" ]]; then composer require --dev --no-update phpunit/phpunit:~6.5; fi
+  - composer install
 script:
   - phpunit --configuration phpunit.xml --coverage-text --coverage-clover=coverage.xml
   # Run style fixer in test mode on all source files. Will exit with a non-zero


### PR DESCRIPTION
Added a build matrix to test the library with newer phpunit version.

The matrix excludes the build with php 5.6 and phpunit ~6.5