### PR TITLE
Check if salesfrequency is a non negative integer

### DIFF
--- a/src/FINDOLOGIC/Export/Data/SalesFrequency.php
+++ b/src/FINDOLOGIC/Export/Data/SalesFrequency.php
@@ -5,11 +5,11 @@ namespace FINDOLOGIC\Export\Data;
 use FINDOLOGIC\Export\Helpers\UsergroupAwareSimpleValue;
 use FINDOLOGIC\Export\Helpers\EmptyValueNotAllowedException;
 
-class ValueIsNotPositivIntegerException extends \RuntimeException
+class ValueIsNotPositiveIntegerException extends \RuntimeException
 {
-    public function __construct()
+    public function __construct($value)
     {
-        parent::__construct('Value is not a positiv integer!');
+        parent::__construct(sprintf('%s is not an positive integer!', $value));
     }
 }
 
@@ -27,7 +27,7 @@ class SalesFrequency extends UsergroupAwareSimpleValue
         }
 
         if (!is_int($value) || $value < 0) {
-            throw new ValueIsNotPositivIntegerException();
+            throw new ValueIsNotPositiveIntegerException($value);
         }
 
         return $value;

--- a/src/FINDOLOGIC/Export/Data/SalesFrequency.php
+++ b/src/FINDOLOGIC/Export/Data/SalesFrequency.php
@@ -2,12 +2,34 @@
 
 namespace FINDOLOGIC\Export\Data;
 
-use FINDOLOGIC\Export\Helpers\UsergroupAwareNumericValue;
+use FINDOLOGIC\Export\Helpers\UsergroupAwareSimpleValue;
+use FINDOLOGIC\Export\Helpers\EmptyValueNotAllowedException;
 
-class SalesFrequency extends UsergroupAwareNumericValue
+class ValueIsNotPositivIntegerException extends \RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('Value is not a positiv integer!');
+    }
+}
+
+class SalesFrequency extends UsergroupAwareSimpleValue
 {
     public function __construct()
     {
         parent::__construct('salesFrequencies', 'salesFrequency');
+    }
+
+    protected function validate($value)
+    {
+        if ($value === '') {
+            throw new EmptyValueNotAllowedException();
+        }
+
+        if (!is_int($value) || $value < 0) {
+            throw new ValueIsNotPositivIntegerException();
+        }
+
+        return $value;
     }
 }

--- a/tests/FINDOLOGIC/Export/Tests/DataElementsTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/DataElementsTest.php
@@ -12,7 +12,7 @@ use FINDOLOGIC\Export\Data\Ordernumber;
 use FINDOLOGIC\Export\Data\Price;
 use FINDOLOGIC\Export\Data\Property;
 use FINDOLOGIC\Export\Data\SalesFrequency;
-use FINDOLOGIC\Export\Data\ValueIsNotPositivIntegerException;
+use FINDOLOGIC\Export\Data\ValueIsNotPositiveIntegerException;
 use FINDOLOGIC\Export\Data\Sort;
 use FINDOLOGIC\Export\Data\Summary;
 use FINDOLOGIC\Export\Data\Url;
@@ -88,9 +88,9 @@ class DataElementsTest extends TestCase
                 EmptyValueNotAllowedException::class],
             'SalesFrequency with positive integer value' => [1337, SalesFrequency::class, null],
             'SalesFrequency with negative integer value' => [-1, SalesFrequency::class,
-                ValueIsNotPositivIntegerException::class],
+                ValueIsNotPositiveIntegerException::class],
             'SalesFrequency with non integer value' => ['test', SalesFrequency::class,
-                ValueIsNotPositivIntegerException::class],
+                ValueIsNotPositiveIntegerException::class],
             'Sort with empty value' => ['', Sort::class, EmptyValueNotAllowedException::class],
             'Sort with value' => [1337, Sort::class, null],
             'Sort with non-numeric value' => ['test', Sort::class, ValueIsNotNumericException::class],

--- a/tests/FINDOLOGIC/Export/Tests/DataElementsTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/DataElementsTest.php
@@ -12,6 +12,7 @@ use FINDOLOGIC\Export\Data\Ordernumber;
 use FINDOLOGIC\Export\Data\Price;
 use FINDOLOGIC\Export\Data\Property;
 use FINDOLOGIC\Export\Data\SalesFrequency;
+use FINDOLOGIC\Export\Data\ValueIsNotPositivIntegerException;
 use FINDOLOGIC\Export\Data\Sort;
 use FINDOLOGIC\Export\Data\Summary;
 use FINDOLOGIC\Export\Data\Url;
@@ -85,9 +86,11 @@ class DataElementsTest extends TestCase
             'Price with non-numeric value' => ['test', Price::class, ValueIsNotNumericException::class],
             'SalesFrequency with empty value' => ['', SalesFrequency::class,
                 EmptyValueNotAllowedException::class],
-            'SalesFrequency with value' => [1337, SalesFrequency::class, null],
-            'SalesFrequency with non-numeric value' => ['test', SalesFrequency::class,
-                ValueIsNotNumericException::class],
+            'SalesFrequency with positive integer value' => [1337, SalesFrequency::class, null],
+            'SalesFrequency with negative integer value' => [-1, SalesFrequency::class,
+                ValueIsNotPositivIntegerException::class],
+            'SalesFrequency with non integer value' => ['test', SalesFrequency::class,
+                ValueIsNotPositivIntegerException::class],
             'Sort with empty value' => ['', Sort::class, EmptyValueNotAllowedException::class],
             'Sort with value' => [1337, Sort::class, null],
             'Sort with non-numeric value' => ['test', Sort::class, ValueIsNotNumericException::class],


### PR DESCRIPTION
Until know we checked if the salesfrequency input was a numeric value. As mentioned in [the documentation](https://docs.findologic.com/doku.php?id=export_patterns:xml#salesfrequencies) the input must be a non negative integer.