### PR TITLE
Validate that sort value is integer

### DIFF
--- a/src/FINDOLOGIC/Export/Data/Sort.php
+++ b/src/FINDOLOGIC/Export/Data/Sort.php
@@ -2,12 +2,34 @@
 
 namespace FINDOLOGIC\Export\Data;
 
-use FINDOLOGIC\Export\Helpers\UsergroupAwareNumericValue;
+use FINDOLOGIC\Export\Helpers\UsergroupAwareSimpleValue;
+use FINDOLOGIC\Export\Helpers\EmptyValueNotAllowedException;
 
-class Sort extends UsergroupAwareNumericValue
+class ValueIsNotIntegerException extends \RuntimeException
+{
+    public function __construct($value)
+    {
+        parent::__construct(sprintf('%s is not an integer!', $value));
+    }
+}
+
+class Sort extends UsergroupAwareSimpleValue
 {
     public function __construct()
     {
         parent::__construct('sorts', 'sort');
+    }
+
+    protected function validate($value)
+    {
+        if ($value === '') {
+            throw new EmptyValueNotAllowedException();
+        }
+
+        if (!is_int($value)) {
+            throw new ValueIsNotIntegerException($value);
+        }
+
+        return $value;
     }
 }

--- a/tests/FINDOLOGIC/Export/Tests/DataElementsTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/DataElementsTest.php
@@ -12,6 +12,7 @@ use FINDOLOGIC\Export\Data\Ordernumber;
 use FINDOLOGIC\Export\Data\Price;
 use FINDOLOGIC\Export\Data\Property;
 use FINDOLOGIC\Export\Data\SalesFrequency;
+use FINDOLOGIC\Export\Data\ValueIsNotIntegerException;
 use FINDOLOGIC\Export\Data\ValueIsNotPositiveIntegerException;
 use FINDOLOGIC\Export\Data\Sort;
 use FINDOLOGIC\Export\Data\Summary;
@@ -92,8 +93,9 @@ class DataElementsTest extends TestCase
             'SalesFrequency with non integer value' => ['test', SalesFrequency::class,
                 ValueIsNotPositiveIntegerException::class],
             'Sort with empty value' => ['', Sort::class, EmptyValueNotAllowedException::class],
-            'Sort with value' => [1337, Sort::class, null],
-            'Sort with non-numeric value' => ['test', Sort::class, ValueIsNotNumericException::class],
+            'Sort with integer' => [1337, Sort::class, null],
+            'Sort with string' => ['test', Sort::class, ValueIsNotIntegerException::class],
+            'Sort with float' => [5.4, Sort::class, ValueIsNotIntegerException::class],
             'Summary with empty value' => ['', Summary::class, EmptyValueNotAllowedException::class],
             'Summary with value' => ['value', Summary::class, null],
             'Url with empty value' => ['', Url::class, EmptyValueNotAllowedException::class],


### PR DESCRIPTION
As described in our XSD-Schema, the value of the sort element has to be an integer.