### PR TITLE
Check if property value array is associative

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ env:
     - PHPUNIT_VERSION="6.5"
     - PHPUNIT_VERSION="7.0"
 
-  global:
-    - PATH=$PATH:vendor/bin
-
 matrix:
   exclude:
   - php: 5.6
@@ -31,9 +28,9 @@ install:
 script:
   # Run style fixer in test mode on all source files. Will exit with a non-zero
   # return code if something needs changing.
-  - php-cs-fixer fix --dry-run src
-  - php-cs-fixer fix --dry-run tests
-  - phpunit --configuration phpunit.xml --coverage-text --coverage-clover=coverage.xml
+  - ./vendor/bin/php-cs-fixer fix --dry-run src
+  - ./vendor/bin/php-cs-fixer fix --dry-run tests
+  - ./vendor/bin/phpunit --configuration phpunit.xml --coverage-text --coverage-clover=coverage.xml
 
 after_success:
     - bash <(curl -s https://codecov.io/bash)

--- a/src/FINDOLOGIC/Export/Data/Property.php
+++ b/src/FINDOLOGIC/Export/Data/Property.php
@@ -20,6 +20,15 @@ class PropertyKeyNotAllowedException extends \RuntimeException
     }
 }
 
+class NonAssociativePropertyValueException extends \RuntimeException
+{
+    public function __construct($key)
+    {
+        $format = 'Property values have to be associative, like $key => $value. The key "%s" has to be a string, integer given.';
+        parent::__construct(sprintf($format, $key));
+    }
+}
+
 class Property
 {
     /**
@@ -82,6 +91,8 @@ class Property
     {
         $this->values = [];
 
+        array_walk($values, array($this, 'checkIsAssociativeArray'));
+
         foreach ($values as $usergroup => $value) {
             $this->addValue($value, $usergroup);
         }
@@ -90,5 +101,16 @@ class Property
     public function getAllValues()
     {
         return $this->values;
+    }
+
+    private function checkIsAssociativeArray($item, $key)
+    {
+        /**
+         * The key of a sequential array is an integer. This makes sure
+         * that the key of the array is a string like an associative array.
+         */
+        if (!is_string($key)) {
+            throw new NonAssociativePropertyValueException($key);
+        }
     }
 }

--- a/tests/FINDOLOGIC/Export/Tests/DataElementsTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/DataElementsTest.php
@@ -152,8 +152,8 @@ class DataElementsTest extends TestCase
             'Attribute with empty value' => ['key', [''], Attribute::class, true],
             'Attribute with valid key and value' => ['key', ['value'], Attribute::class, false],
             'Property with empty key' => ['',['value'], Property::class, true],
-            'Property with empty value' => ['key', [''], Property::class, true],
-            'Property with valid key and value' => ['key', ['value'], Property::class, false]
+            'Property with empty value' => ['key', ['foo' => ''], Property::class, true],
+            'Property with valid key and value' => ['key', ['foo' => 'bar'], Property::class, false]
         ];
     }
 

--- a/tests/FINDOLOGIC/Export/Tests/PropertyTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/PropertyTest.php
@@ -57,7 +57,7 @@ class PropertyTest extends TestCase
     }
 
     /**
-     * @expectedException \FINDOLOGIC\Export\Data\NonAssociativePropertyValueException
+     * @expectedException \PHPUnit_Framework_Error_Warning
      */
     public function testNonAssociativePropertyValueCausesException()
     {

--- a/tests/FINDOLOGIC/Export/Tests/PropertyTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/PropertyTest.php
@@ -55,4 +55,12 @@ class PropertyTest extends TestCase
             $this->assertRegExp('/' . $key . '/', $exception->getMessage());
         }
     }
+
+    /**
+     * @expectedException \FINDOLOGIC\Export\Data\NonAssociativePropertyValueException
+     */
+    public function testNonAssociativePropertyValueCausesException()
+    {
+        $property = new Property('foo', ['bar']);
+    }
 }

--- a/tests/FINDOLOGIC/Export/Tests/PropertyTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/PropertyTest.php
@@ -56,11 +56,13 @@ class PropertyTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
-     */
     public function testNonAssociativePropertyValueCausesException()
     {
-        $property = new Property('foo', ['bar']);
+        try {
+            $property = new Property('foo', ['bar']);
+        } catch (\Exception $exception) {
+            $warningMessage = 'Property values have to be associative, like $key => $value. The key "0" has to be a string, integer given.';
+            $this->assertEquals($exception->getMessage(), $warningMessage);
+        }
     }
 }


### PR DESCRIPTION
Make sure the provided array of values which can be assigned as a whole to the property is associative like `'usergroup' => 'usergroupspecific value'`.

 - [x] Trigger warning if a non associative array is assigned to the property
 - [x] Fix travis config to make sure phpunit is loaded from the vendor folder