### PR TITLE
Drop support for php 5.6 and 7.0 and update phpunit to current version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,10 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
 
-env:
-  matrix:
-    - PHPUNIT_VERSION="5.7"
-    - PHPUNIT_VERSION="6.5"
-    - PHPUNIT_VERSION="7.0"
-
-matrix:
-  exclude:
-  - php: 5.6
-    env: PHPUNIT_VERSION="6.5"
-  - php: 5.6
-    env: PHPUNIT_VERSION="7.0"
-  - php: 7.0
-    env: PHPUNIT_VERSION="7.0"
-
 install:
-  - if [[ "$PHPUNIT_VERSION" = "6.5" ]]; then composer require --dev --no-update phpunit/phpunit:~6.5; fi
-  - if [[ "$PHPUNIT_VERSION" = "7.0" ]]; then composer require --dev --no-update phpunit/phpunit:~7.0; fi
   - composer install
 script:
   # Run style fixer in test mode on all source files. Will exit with a non-zero

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "FINDOLOGIC export toolkit for XML and CSV data export",
     "homepage": "https://github.com/findologic/libflexport",
     "require-dev": {
-        "phpunit/phpunit": "~5.7",
+        "phpunit/phpunit": "~7.4",
         "symfony/console": "v3.2.9",
         "friendsofphp/php-cs-fixer": "v2.8.2"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,7 +9,6 @@
     convertWarningsToExceptions = "true"
     processIsolation            = "false"
     stopOnFailure               = "false"
-    syntaxCheck                 = "false"
     bootstrap                   = "vendor/autoload.php"
 >
     <testsuites>

--- a/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
@@ -375,6 +375,8 @@ class XmlSerializationTest extends TestCase
             $item = $this->getMinimalItem();
             $url =  new Url($value);
             $item->setUrl($url);
+
+            $this->assertNotNull($url);
         } catch (\Exception $e) {
             $this->assertEquals($expectedException, get_class($e));
         }
@@ -384,6 +386,8 @@ class XmlSerializationTest extends TestCase
     {
         $page = new Page(0, 1, 1);
         $page->addItem($this->getMinimalItem());
+
+        $this->assertNotNull($page);
     }
 
     public function unsupportedValueProvider()


### PR DESCRIPTION
This solves #73.

This should be merged as soon as the support for the two PHP versions expires.

The branch `php_version_update` was set up to merge this one.