### PR TITLE
Use addItem method when setting all items at once to XML page

### DIFF
--- a/src/FINDOLOGIC/Export/XML/Page.php
+++ b/src/FINDOLOGIC/Export/XML/Page.php
@@ -35,7 +35,11 @@ class Page
 
     public function setAllItems(array $items)
     {
-        $this->items = $items;
+        $this->items = [];
+
+        foreach ($items as $item) {
+            $this->addItem($item);
+        }
     }
 
     /**


### PR DESCRIPTION
This was added for consitancy as we use this type of add method at other places. Furthermore if we would need to check anything on the added items we can extend checks in the addItem method.