### PR TITLE
Remove obsolete phpunit configuration entries

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,14 +2,7 @@
 
 <phpunit
     backupGlobals               = "false"
-    backupStaticAttributes      = "false"
     colors                      = "true"
-    convertErrorsToExceptions   = "true"
-    convertNoticesToExceptions  = "true"
-    convertWarningsToExceptions = "true"
-    processIsolation            = "false"
-    stopOnFailure               = "false"
-    syntaxCheck                 = "false"
     bootstrap                   = "vendor/autoload.php"
 >
     <testsuites>


### PR DESCRIPTION
This fixes #79 

The branch `php_version_update` was set up to merge this one.