### PR TITLE
Add missing data provider for url validation

### DIFF
--- a/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
@@ -375,12 +375,12 @@ class XmlSerializationTest extends TestCase
      * @param string $value
      * @param \Exception|null $expectedException
      */
-    public function testUrlValidationWorks($value = '', $expectedException = null)
+    public function testUrlValidationWorks($value, $expectedException)
     {
         try {
-            $item = $this->getMinimalItem();
-            $url =  new Url($value);
-            $item->setUrl($url);
+            $url =  new Url();
+            $url->setValue($value);
+            $url->getDomSubtree(new \DOMDocument());
         } catch (\Exception $e) {
             $this->assertEquals($expectedException, get_class($e));
         }
@@ -390,6 +390,7 @@ class XmlSerializationTest extends TestCase
     {
         $page = new Page(0, 1, 1);
         $page->addItem($this->getMinimalItem());
+        $this->assertNotNull($page->getXml());
     }
 
     public function unsupportedValueProvider()

--- a/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
@@ -369,6 +369,12 @@ class XmlSerializationTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider urlValidationProvider
+     *
+     * @param string $value
+     * @param \Exception|null $expectedException
+     */
     public function testUrlValidationWorks($value = '', $expectedException = null)
     {
         try {


### PR DESCRIPTION
## Purpose

The dataprovider for the test `testUrlValidationWorks` wasn't implemented in the docblock for phpunit.

## Approach

Add dataprovider in docblock

#### Open Questions and Pre-Merge TODOs

- [x] `php-cs-fixer` was executed.
- [x] Tests were written and pass with 100% coverage.
