### PR TITLE
Element value validation

### DIFF
--- a/src/FINDOLOGIC/Export/Data/Item.php
+++ b/src/FINDOLOGIC/Export/Data/Item.php
@@ -348,6 +348,10 @@ abstract class Item implements Serializable
      */
     public function addProperty(Property $property)
     {
+        if (count($property->getAllValues()) === 0) {
+            throw new EmptyElementsNotAllowedException('Property', $property->getKey());
+        }
+
         foreach ($property->getAllValues() as $usergroup => $value) {
             if (!array_key_exists($usergroup, $this->properties)) {
                 $this->properties[$usergroup] = [];

--- a/src/FINDOLOGIC/Export/Data/Item.php
+++ b/src/FINDOLOGIC/Export/Data/Item.php
@@ -5,6 +5,15 @@ namespace FINDOLOGIC\Export\Data;
 use DateTime;
 use FINDOLOGIC\Export\Helpers\Serializable;
 
+class EmptyElementsNotAllowedException extends \RuntimeException
+{
+    public function __construct($elementType, $elementKey)
+    {
+        $message = "Elements with empty values are not allowed. '{$elementType}' with the name '{$elementKey}'";
+        parent::__construct($message);
+    }
+}
+
 abstract class Item implements Serializable
 {
     protected $id;
@@ -355,6 +364,10 @@ abstract class Item implements Serializable
      */
     public function addAttribute(Attribute $attribute)
     {
+        if (count($attribute->getValues()) === 0) {
+            throw new EmptyElementsNotAllowedException('Attribute', $attribute->getKey());
+        }
+
         $this->attributes[$attribute->getKey()] = $attribute;
     }
 

--- a/src/FINDOLOGIC/Export/Helpers/UsergroupAwareSimpleValue.php
+++ b/src/FINDOLOGIC/Export/Helpers/UsergroupAwareSimpleValue.php
@@ -27,7 +27,7 @@ abstract class UsergroupAwareSimpleValue implements Serializable
 
     /**
      * @SuppressWarnings(PHPMD.StaticAccess)
-     * @param $value The value of the element.
+     * @param mixed $value The value of the element.
      * @param string $usergroup The usergroup of the element.
      */
     public function setValue($value, $usergroup = '')

--- a/src/FINDOLOGIC/Export/Helpers/UsergroupAwareSimpleValue.php
+++ b/src/FINDOLOGIC/Export/Helpers/UsergroupAwareSimpleValue.php
@@ -27,7 +27,7 @@ abstract class UsergroupAwareSimpleValue implements Serializable
 
     /**
      * @SuppressWarnings(PHPMD.StaticAccess)
-     * @param mixed $value The value of the element.
+     * @param string|int|float $value The value of the element.
      * @param string $usergroup The usergroup of the element.
      */
     public function setValue($value, $usergroup = '')

--- a/tests/FINDOLOGIC/Export/Tests/ItemTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/ItemTest.php
@@ -4,6 +4,7 @@ namespace FINDOLOGIC\Export\Tests;
 
 use FINDOLOGIC\Export\Data\Attribute;
 use FINDOLOGIC\Export\Data\Price;
+use FINDOLOGIC\Export\Data\Property;
 use FINDOLOGIC\Export\Exporter;
 use FINDOLOGIC\Export\XML\XMLExporter;
 use PHPUnit\Framework\TestCase;
@@ -41,5 +42,15 @@ class ItemTest extends TestCase
         $item = $this->getMinimalItem();
         $attribute = new Attribute('empty attribute', []);
         $item->addAttribute($attribute);
+    }
+
+    /**
+     * @expectedException \FINDOLOGIC\Export\Data\EmptyElementsNotAllowedException
+     */
+    public function testAddingEmptyPropertiesCauseException()
+    {
+        $item = $this->getMinimalItem();
+        $property = new Property('empty property', []);
+        $item->addProperty($property);
     }
 }

--- a/tests/FINDOLOGIC/Export/Tests/ItemTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/ItemTest.php
@@ -41,6 +41,7 @@ class ItemTest extends TestCase
             $item = $this->getMinimalItem();
             $attribute = new Attribute('empty attribute', []);
             $item->addAttribute($attribute);
+            $this->fail('Assigning attributes with empty values should cause an exception!');
         } catch (EmptyElementsNotAllowedException $e) {
             $expectedMessage = "Elements with empty values are not allowed. 'Attribute' with the name 'empty attribute'";
             $this->assertEquals($expectedMessage, $e->getMessage());
@@ -53,6 +54,7 @@ class ItemTest extends TestCase
             $item = $this->getMinimalItem();
             $property = new Property('empty property', []);
             $item->addProperty($property);
+            $this->fail('Assigning properties with empty values should cause an exception!');
         } catch (EmptyElementsNotAllowedException $e) {
             $expectedMessage = "Elements with empty values are not allowed. 'Property' with the name 'empty property'";
             $this->assertEquals($expectedMessage, $e->getMessage());

--- a/tests/FINDOLOGIC/Export/Tests/ItemTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/ItemTest.php
@@ -41,7 +41,7 @@ class ItemTest extends TestCase
             $item = $this->getMinimalItem();
             $attribute = new Attribute('empty attribute', []);
             $item->addAttribute($attribute);
-        } catch(EmptyElementsNotAllowedException $e) {
+        } catch (EmptyElementsNotAllowedException $e) {
             $expectedMessage = "Elements with empty values are not allowed. 'Attribute' with the name 'empty attribute'";
             $this->assertEquals($expectedMessage, $e->getMessage());
         }
@@ -53,7 +53,7 @@ class ItemTest extends TestCase
             $item = $this->getMinimalItem();
             $property = new Property('empty property', []);
             $item->addProperty($property);
-        } catch(EmptyElementsNotAllowedException $e) {
+        } catch (EmptyElementsNotAllowedException $e) {
             $expectedMessage = "Elements with empty values are not allowed. 'Property' with the name 'empty property'";
             $this->assertEquals($expectedMessage, $e->getMessage());
         }

--- a/tests/FINDOLOGIC/Export/Tests/ItemTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/ItemTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace FINDOLOGIC\Export\Tests;
+
+use FINDOLOGIC\Export\Data\Attribute;
+use FINDOLOGIC\Export\Data\Price;
+use FINDOLOGIC\Export\Exporter;
+use FINDOLOGIC\Export\XML\XMLExporter;
+use PHPUnit\Framework\TestCase;
+
+class ItemTest extends TestCase
+{
+
+    /** @var XMLExporter */
+    private $exporter;
+
+    /**
+     * @SuppressWarnings(PHPMD.StaticAccess)
+     */
+    public function setUp()
+    {
+        $this->exporter = Exporter::create(Exporter::TYPE_XML);
+    }
+
+    private function getMinimalItem()
+    {
+        $item = $this->exporter->createItem('123');
+
+        $price = new Price();
+        $price->setValue('13.37');
+        $item->setPrice($price);
+
+        return $item;
+    }
+
+    /**
+     * @expectedException \FINDOLOGIC\Export\Data\EmptyElementsNotAllowedException
+     */
+    public function testAddingEmptyAttributesCauseException()
+    {
+        $item = $this->getMinimalItem();
+        $attribute = new Attribute('empty attribute', []);
+        $item->addAttribute($attribute);
+    }
+}

--- a/tests/FINDOLOGIC/Export/Tests/ItemTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/ItemTest.php
@@ -3,6 +3,7 @@
 namespace FINDOLOGIC\Export\Tests;
 
 use FINDOLOGIC\Export\Data\Attribute;
+use FINDOLOGIC\Export\Data\EmptyElementsNotAllowedException;
 use FINDOLOGIC\Export\Data\Price;
 use FINDOLOGIC\Export\Data\Property;
 use FINDOLOGIC\Export\Exporter;
@@ -34,23 +35,27 @@ class ItemTest extends TestCase
         return $item;
     }
 
-    /**
-     * @expectedException \FINDOLOGIC\Export\Data\EmptyElementsNotAllowedException
-     */
     public function testAddingEmptyAttributesCauseException()
     {
-        $item = $this->getMinimalItem();
-        $attribute = new Attribute('empty attribute', []);
-        $item->addAttribute($attribute);
+        try {
+            $item = $this->getMinimalItem();
+            $attribute = new Attribute('empty attribute', []);
+            $item->addAttribute($attribute);
+        } catch(EmptyElementsNotAllowedException $e) {
+            $expectedMessage = "Elements with empty values are not allowed. 'Attribute' with the name 'empty attribute'";
+            $this->assertEquals($expectedMessage, $e->getMessage());
+        }
     }
 
-    /**
-     * @expectedException \FINDOLOGIC\Export\Data\EmptyElementsNotAllowedException
-     */
     public function testAddingEmptyPropertiesCauseException()
     {
-        $item = $this->getMinimalItem();
-        $property = new Property('empty property', []);
-        $item->addProperty($property);
+        try {
+            $item = $this->getMinimalItem();
+            $property = new Property('empty property', []);
+            $item->addProperty($property);
+        } catch(EmptyElementsNotAllowedException $e) {
+            $expectedMessage = "Elements with empty values are not allowed. 'Property' with the name 'empty property'";
+            $this->assertEquals($expectedMessage, $e->getMessage());
+        }
     }
 }


### PR DESCRIPTION
## Purpose

This PR allows missing validation of elements like attributes and properties as mention in the issue #89.

## Approach

More validation of the export.

#### Open Questions and Pre-Merge TODOs

- [x] `php-cs-fixer` was executed.
- [x] Tests were written and pass with 100% coverage.
- [x] A issue with a detailed explanation of the problem/enhancement was created and linked.
