### PR TITLE
Php version update return types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,11 @@
     "name": "findologic/libflexport",
     "description": "FINDOLOGIC export toolkit for XML and CSV data export",
     "homepage": "https://github.com/findologic/libflexport",
+    "require": {
+        "php": "^7.1"
+    },
     "require-dev": {
-        "phpunit/phpunit": "~7.4",
+        "phpunit/phpunit": "~7.5",
         "symfony/console": "v3.2.9",
         "squizlabs/php_codesniffer": "3.3.*"
     },

--- a/src/FINDOLOGIC/Export/CSV/CSVExporter.php
+++ b/src/FINDOLOGIC/Export/CSV/CSVExporter.php
@@ -2,14 +2,14 @@
 
 namespace FINDOLOGIC\Export\CSV;
 
+use FINDOLOGIC\Export\Data\Item;
 use FINDOLOGIC\Export\Exporter;
-use FINDOLOGIC\Export\Exceptions\BadPropertyKeyException;
 use FINDOLOGIC\Export\Helpers\DataHelper;
 
 class CSVExporter extends Exporter
 {
-    private const HEADING = "id\tordernumber\tname\tsummary\tdescription\tprice\tinstead\tmaxprice\ttaxrate\turl\timage\t" .
-        "attributes\tkeywords\tgroups\tbonus\tsales_frequency\tdate_added\tsort";
+    private const HEADING = "id\tordernumber\tname\tsummary\tdescription\tprice\tinstead\tmaxprice\ttaxrate\turl\t" .
+        "image\tattributes\tkeywords\tgroups\tbonus\tsales_frequency\tdate_added\tsort";
 
     /**
      * @var array Names of properties; used for alignment of extra columns containing property values.
@@ -26,7 +26,7 @@ class CSVExporter extends Exporter
     /**
      * @inheritdoc
      */
-    public function serializeItems(array $items, int $start = 0, int $count = 0, int $total = 0)
+    public function serializeItems(array $items, int $start = 0, int $count = 0, int $total = 0): string
     {
         $export = '';
         // To enable pagination, don't write the heading if it's anything but the first page.
@@ -52,8 +52,13 @@ class CSVExporter extends Exporter
     /**
      * @inheritdoc
      */
-    public function serializeItemsToFile(string $targetDirectory, array $items, int $start = 0, int $count = 0, int $total = 0)
-    {
+    public function serializeItemsToFile(
+        string $targetDirectory,
+        array $items,
+        int $start = 0,
+        int $count = 0,
+        int $total = 0
+    ): string {
         $csvString = $this->serializeItems($items, $start, $count, $total);
         $targetPath = sprintf('%s/findologic.csv', $targetDirectory);
 
@@ -65,7 +70,7 @@ class CSVExporter extends Exporter
     /**
      * @inheritdoc
      */
-    public function createItem($id)
+    public function createItem($id): Item
     {
         return new CSVItem($id);
     }

--- a/src/FINDOLOGIC/Export/CSV/CSVItem.php
+++ b/src/FINDOLOGIC/Export/CSV/CSVItem.php
@@ -11,7 +11,7 @@ class CSVItem extends Item
     /**
      * @inheritdoc
      */
-    public function getDomSubtree(\DOMDocument $document)
+    public function getDomSubtree(\DOMDocument $document): void
     {
         throw new \BadMethodCallException('CSVItem does not implement XML export.');
     }
@@ -19,7 +19,7 @@ class CSVItem extends Item
     /**
      * @inheritdoc
      */
-    public function getCsvFragment(array $availableProperties = [])
+    public function getCsvFragment(array $availableProperties = []): string
     {
         $that = $this; // Used in closure.
 
@@ -74,7 +74,7 @@ class CSVItem extends Item
         return $line;
     }
 
-    private function buildProperties(array $availableProperties)
+    private function buildProperties(array $availableProperties): string
     {
         $propertiesString = '';
 
@@ -89,7 +89,7 @@ class CSVItem extends Item
         return $propertiesString;
     }
 
-    private function buildAttributes()
+    private function buildAttributes(): string
     {
         $attributes = '';
 
@@ -103,7 +103,7 @@ class CSVItem extends Item
         return $attributes;
     }
 
-    private function buildImages()
+    private function buildImages(): string
     {
         // Use the first available image that is not restricted by usergroup. If more than one usergroup-less image
         // exists, cause an error because it's no longer certain which one is intended to be used.
@@ -123,7 +123,7 @@ class CSVItem extends Item
         return $imageUrl;
     }
 
-    private function sanitize($input, $stripTags = true)
+    private function sanitize($input, $stripTags = true): string
     {
         if ($stripTags) {
             $input = strip_tags($input);

--- a/src/FINDOLOGIC/Export/Data/AllKeywords.php
+++ b/src/FINDOLOGIC/Export/Data/AllKeywords.php
@@ -16,7 +16,7 @@ class AllKeywords extends UsergroupAwareMultiValue
      *      knows into which column to write its property value, if any.
      * @return string A CSV fragment that, combined with other fragments, will finally become an export file.
      */
-    public function getCsvFragment(array $availableProperties = [])
+    public function getCsvFragment(array $availableProperties = []): string
     {
         if (array_key_exists('', $this->values)) {
             return implode(',', array_map(function ($keyword) {

--- a/src/FINDOLOGIC/Export/Data/AllOrdernumbers.php
+++ b/src/FINDOLOGIC/Export/Data/AllOrdernumbers.php
@@ -14,7 +14,7 @@ class AllOrdernumbers extends UsergroupAwareMultiValue
     /**
      * @inheritdoc
      */
-    public function getCsvFragment(array $availableProperties = [])
+    public function getCsvFragment(array $availableProperties = []): string
     {
         if (array_key_exists('', $this->values)) {
             return implode('|', array_map(function ($ordernumber) {

--- a/src/FINDOLOGIC/Export/Data/Attribute.php
+++ b/src/FINDOLOGIC/Export/Data/Attribute.php
@@ -8,8 +8,10 @@ use FINDOLOGIC\Export\Helpers\XMLHelper;
 
 class Attribute implements Serializable
 {
+    /** @var string */
     private $key;
 
+    /** @var array */
     private $values;
 
     /**
@@ -26,13 +28,13 @@ class Attribute implements Serializable
     /**
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    public function addValue($value)
+    public function addValue($value): void
     {
         DataHelper::checkAttributeValueNotExceedingCharacterLimit($this->getKey(), $value);
         array_push($this->values, DataHelper::checkForEmptyValue($value));
     }
 
-    public function setValues(array $values)
+    public function setValues(array $values): void
     {
         $this->values = [];
 
@@ -41,12 +43,12 @@ class Attribute implements Serializable
         }
     }
 
-    public function getValues()
+    public function getValues(): array
     {
         return $this->values;
     }
 
-    public function getKey()
+    public function getKey(): string
     {
         return $this->key;
     }
@@ -55,7 +57,7 @@ class Attribute implements Serializable
      * @SuppressWarnings(PHPMD.StaticAccess)
      * @inheritdoc
      */
-    public function getDomSubtree(\DOMDocument $document)
+    public function getDomSubtree(\DOMDocument $document): \DOMElement
     {
         $attributeElem = XMLHelper::createElement($document, 'attribute');
 
@@ -76,7 +78,7 @@ class Attribute implements Serializable
     /**
      * @inheritdoc
      */
-    public function getCsvFragment(array $availableProperties = [])
+    public function getCsvFragment(array $availableProperties = []): string
     {
         $attributeParts = [];
 

--- a/src/FINDOLOGIC/Export/Data/DateAdded.php
+++ b/src/FINDOLOGIC/Export/Data/DateAdded.php
@@ -12,19 +12,19 @@ class DateAdded extends UsergroupAwareSimpleValue
         parent::__construct('dateAddeds', 'dateAdded');
     }
 
-    public function setValue($value, string $usergroup = '')
+    public function setValue($value, string $usergroup = ''): void
     {
         throw new \BadMethodCallException('Assign DateAdded values by passing a \DateTime to setDateValue()');
     }
 
-    public function setDateValue(DateTime $value, string $usergroup = '')
+    public function setDateValue(DateTime $value, string $usergroup = ''): void
     {
         $formatted = $value->format(DateTime::ATOM);
 
         parent::setValue($formatted, $usergroup);
     }
 
-    public function getCsvFragment(array $availableProperties = [])
+    public function getCsvFragment(array $availableProperties = []): string
     {
         $date = DateTime::createFromFormat(DATE_ATOM, $this->getValues()['']);
 

--- a/src/FINDOLOGIC/Export/Data/Image.php
+++ b/src/FINDOLOGIC/Export/Data/Image.php
@@ -18,8 +18,13 @@ class Image implements Serializable
      */
     public const TYPE_THUMBNAIL = 'thumbnail';
 
+    /** @var string */
     private $url;
+
+    /** @var string */
     private $type;
+
+    /** @var string */
     private $usergroup;
 
     /**
@@ -38,12 +43,12 @@ class Image implements Serializable
     /**
      * @return string
      */
-    public function getUrl()
+    public function getUrl(): string
     {
         return $this->url;
     }
 
-    private function setUrl(string $url)
+    private function setUrl(string $url): void
     {
         $url = DataHelper::checkForEmptyValue($url);
 
@@ -53,7 +58,7 @@ class Image implements Serializable
     /**
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
@@ -61,7 +66,7 @@ class Image implements Serializable
     /**
      * @return string
      */
-    public function getUsergroup()
+    public function getUsergroup(): string
     {
         return $this->usergroup;
     }
@@ -70,7 +75,7 @@ class Image implements Serializable
      * @SuppressWarnings(PHPMD.StaticAccess)
      * @inheritdoc
      */
-    public function getDomSubtree(\DOMDocument $document)
+    public function getDomSubtree(\DOMDocument $document): \DOMElement
     {
         $imageElem = XMLHelper::createElementWithText($document, 'image', DataHelper::validateUrl($this->getUrl()));
         if ($this->getType()) {
@@ -83,7 +88,7 @@ class Image implements Serializable
     /**
      * @inheritdoc
      */
-    public function getCsvFragment(array $availableProperties = [])
+    public function getCsvFragment(array $availableProperties = []): string
     {
         return $this->getUrl();
     }

--- a/src/FINDOLOGIC/Export/Data/Item.php
+++ b/src/FINDOLOGIC/Export/Data/Item.php
@@ -76,7 +76,7 @@ abstract class Item implements Serializable
         $this->ordernumbers = new AllOrdernumbers();
     }
 
-    public function getName()
+    public function getName(): Name
     {
         return $this->name;
     }
@@ -84,7 +84,7 @@ abstract class Item implements Serializable
     /**
      * @param Name $name The name element to add to the item.
      */
-    public function setName(Name $name)
+    public function setName(Name $name): void
     {
         $this->name = $name;
     }
@@ -95,12 +95,12 @@ abstract class Item implements Serializable
      * @param string $name The name of the item.
      * @param string $usergroup The usergroup of the name element.
      */
-    public function addName(string $name, string $usergroup = '')
+    public function addName(string $name, string $usergroup = ''): void
     {
         $this->name->setValue($name, $usergroup);
     }
 
-    public function getSummary()
+    public function getSummary(): Summary
     {
         return $this->summary;
     }
@@ -108,7 +108,7 @@ abstract class Item implements Serializable
     /**
      * @param Summary $summary The summary element to add to the item.
      */
-    public function setSummary(Summary $summary)
+    public function setSummary(Summary $summary): void
     {
         $this->summary = $summary;
     }
@@ -119,12 +119,12 @@ abstract class Item implements Serializable
      * @param string $summary The summary of the item.
      * @param string $usergroup The usergroup of the summary.
      */
-    public function addSummary(string $summary, string $usergroup = '')
+    public function addSummary(string $summary, string $usergroup = ''): void
     {
         $this->summary->setValue($summary, $usergroup);
     }
 
-    public function getDescription()
+    public function getDescription(): Description
     {
         return $this->description;
     }
@@ -132,7 +132,7 @@ abstract class Item implements Serializable
     /**
      * @param Description $description The description element to add to the item.
      */
-    public function setDescription(Description $description)
+    public function setDescription(Description $description): void
     {
         $this->description = $description;
     }
@@ -143,12 +143,12 @@ abstract class Item implements Serializable
      * @param string $description The description of the item.
      * @param string $usergroup The usergroup of the description.
      */
-    public function addDescription(string $description, string $usergroup = '')
+    public function addDescription(string $description, string $usergroup = ''): void
     {
         $this->description->setValue($description, $usergroup);
     }
 
-    public function getPrice()
+    public function getPrice(): Price
     {
         return $this->price;
     }
@@ -156,7 +156,7 @@ abstract class Item implements Serializable
     /**
      * @param Price $price The price element to add to the item.
      */
-    public function setPrice(Price $price)
+    public function setPrice(Price $price): void
     {
         $this->price = $price;
     }
@@ -167,7 +167,7 @@ abstract class Item implements Serializable
      * @param string $price The price of the item.
      * @param string $usergroup The usergroup of the price.
      */
-    public function addPrice($price, $usergroup = '')
+    public function addPrice($price, $usergroup = ''): void
     {
         if ($this->price === null) {
             $this->price = new Price();
@@ -176,7 +176,7 @@ abstract class Item implements Serializable
         $this->price->setValue($price, $usergroup);
     }
 
-    public function getInsteadPrice()
+    public function getInsteadPrice(): float
     {
         return $this->insteadPrice;
     }
@@ -186,12 +186,12 @@ abstract class Item implements Serializable
      *
      * @param float $insteadPrice The instead price of the item.
      */
-    public function setInsteadPrice(float $insteadPrice)
+    public function setInsteadPrice(float $insteadPrice): void
     {
         $this->insteadPrice = $insteadPrice;
     }
 
-    public function getMaxPrice()
+    public function getMaxPrice(): float
     {
         return $this->maxPrice;
     }
@@ -201,12 +201,12 @@ abstract class Item implements Serializable
      *
      * @param float $maxPrice The instead price of the item.
      */
-    public function setMaxPrice(float $maxPrice)
+    public function setMaxPrice(float $maxPrice): void
     {
         $this->maxPrice = $maxPrice;
     }
 
-    public function getTaxRate()
+    public function getTaxRate(): float
     {
         return $this->taxRate;
     }
@@ -216,12 +216,12 @@ abstract class Item implements Serializable
      *
      * @param float $taxRate The tax rate of the item.
      */
-    public function setTaxRate(float $taxRate)
+    public function setTaxRate(float $taxRate): void
     {
         $this->taxRate = $taxRate;
     }
 
-    public function getUrl()
+    public function getUrl(): Url
     {
         return $this->url;
     }
@@ -229,17 +229,17 @@ abstract class Item implements Serializable
     /**
      * @param Url $url The url element to add to the item.
      */
-    public function setUrl(Url $url)
+    public function setUrl(Url $url): void
     {
         $this->url = $url;
     }
 
-    public function addUrl(string $url, string $usergroup = '')
+    public function addUrl(string $url, string $usergroup = ''): void
     {
         $this->url->setValue($url, $usergroup);
     }
 
-    public function getBonus()
+    public function getBonus(): Bonus
     {
         return $this->bonus;
     }
@@ -247,7 +247,7 @@ abstract class Item implements Serializable
     /**
      * @param Bonus $bonus The bonus element to add to the item.
      */
-    public function setBonus(Bonus $bonus)
+    public function setBonus(Bonus $bonus): void
     {
         $this->bonus = $bonus;
     }
@@ -258,12 +258,12 @@ abstract class Item implements Serializable
      * @param float $bonus The bonus value of the item.
      * @param string $usergroup The usergroup of the bonus value.
      */
-    public function addBonus(float $bonus, string $usergroup = '')
+    public function addBonus(float $bonus, string $usergroup = ''): void
     {
         $this->bonus->setValue($bonus, $usergroup);
     }
 
-    public function getSalesFrequency()
+    public function getSalesFrequency(): SalesFrequency
     {
         return $this->salesFrequency;
     }
@@ -271,7 +271,7 @@ abstract class Item implements Serializable
     /**
      * @param SalesFrequency $salesFrequency The sales frequency element to add to the item.
      */
-    public function setSalesFrequency(SalesFrequency $salesFrequency)
+    public function setSalesFrequency(SalesFrequency $salesFrequency): void
     {
         $this->salesFrequency = $salesFrequency;
     }
@@ -282,12 +282,12 @@ abstract class Item implements Serializable
      * @param int $salesFrequency The sales frequency of the item.
      * @param string $usergroup The usergroup of the sales frequency.
      */
-    public function addSalesFrequency(int $salesFrequency, string $usergroup = '')
+    public function addSalesFrequency(int $salesFrequency, string $usergroup = ''): void
     {
         $this->salesFrequency->setValue($salesFrequency, $usergroup);
     }
 
-    public function getDateAdded()
+    public function getDateAdded(): DateAdded
     {
         return $this->dateAdded;
     }
@@ -295,7 +295,7 @@ abstract class Item implements Serializable
     /**
      * @param DateAdded $dateAdded The date added element to add to the item.
      */
-    public function setDateAdded(DateAdded $dateAdded)
+    public function setDateAdded(DateAdded $dateAdded): void
     {
         $this->dateAdded = $dateAdded;
     }
@@ -306,12 +306,12 @@ abstract class Item implements Serializable
      * @param DateTime $dateAdded The date on which the item was added to the ecommerce system.
      * @param string $usergroup The usergroup of the date added value.
      */
-    public function addDateAdded(DateTime $dateAdded, string $usergroup = '')
+    public function addDateAdded(DateTime $dateAdded, string $usergroup = ''): void
     {
         $this->dateAdded->setDateValue($dateAdded, $usergroup);
     }
 
-    public function getSort()
+    public function getSort(): Sort
     {
         return $this->sort;
     }
@@ -319,7 +319,7 @@ abstract class Item implements Serializable
     /**
      * @param Sort $sort The sort element to add to the item.
      */
-    public function setSort(Sort $sort)
+    public function setSort(Sort $sort): void
     {
         $this->sort = $sort;
     }
@@ -330,7 +330,7 @@ abstract class Item implements Serializable
      * @param int $sort The sort value of the item.
      * @param string $usergroup The usergroup of the sort value.
      */
-    public function addSort(int $sort, string $usergroup = '')
+    public function addSort(int $sort, string $usergroup = ''): void
     {
         $this->sort->setValue($sort, $usergroup);
     }
@@ -338,7 +338,7 @@ abstract class Item implements Serializable
     /**
      * @param Property $property The property element to add to the item.
      */
-    public function addProperty(Property $property)
+    public function addProperty(Property $property): void
     {
         if (count($property->getAllValues()) === 0) {
             throw new EmptyElementsNotAllowedException('Property', $property->getKey());
@@ -358,7 +358,7 @@ abstract class Item implements Serializable
     /**
      * @param Attribute $attribute The attribute element to add to the item.
      */
-    public function addAttribute(Attribute $attribute)
+    public function addAttribute(Attribute $attribute): void
     {
         if (count($attribute->getValues()) === 0) {
             throw new EmptyElementsNotAllowedException('Attribute', $attribute->getKey());
@@ -370,7 +370,7 @@ abstract class Item implements Serializable
     /**
      * @param Image $image The image element to add to the item.
      */
-    public function addImage(Image $image)
+    public function addImage(Image $image): void
     {
         if (!array_key_exists($image->getUsergroup(), $this->images)) {
             $this->images[$image->getUsergroup()] = [];
@@ -382,7 +382,7 @@ abstract class Item implements Serializable
     /**
      * @param array $images Array of image elements which should be added to the item.
      */
-    public function setAllImages(array $images)
+    public function setAllImages(array $images): void
     {
         foreach ($images as $image) {
             $this->addImage($image);
@@ -392,7 +392,7 @@ abstract class Item implements Serializable
     /**
      * @param Ordernumber $ordernumber The ordernumber element to add to the item.
      */
-    public function addOrdernumber(Ordernumber $ordernumber)
+    public function addOrdernumber(Ordernumber $ordernumber): void
     {
         $this->ordernumbers->addValue($ordernumber);
     }
@@ -400,7 +400,7 @@ abstract class Item implements Serializable
     /**
      * @param array $ordernumbers Array of ordernumber elements which should be added to the item.
      */
-    public function setAllOrdernumbers(array $ordernumbers)
+    public function setAllOrdernumbers(array $ordernumbers): void
     {
         $this->ordernumbers->setAllValues($ordernumbers);
     }
@@ -408,7 +408,7 @@ abstract class Item implements Serializable
     /**
      * @param Keyword $keyword The keyword element to add to the item.
      */
-    public function addKeyword(Keyword $keyword)
+    public function addKeyword(Keyword $keyword): void
     {
         $this->keywords->addValue($keyword);
     }
@@ -416,7 +416,7 @@ abstract class Item implements Serializable
     /**
      * @param array $keywords Array of keyword elements which should be added to the item.
      */
-    public function setAllKeywords(array $keywords)
+    public function setAllKeywords(array $keywords): void
     {
         $this->keywords->setAllValues($keywords);
     }
@@ -424,7 +424,7 @@ abstract class Item implements Serializable
     /**
      * @param Usergroup $usergroup The usergroup element to add to the item.
      */
-    public function addUsergroup(Usergroup $usergroup)
+    public function addUsergroup(Usergroup $usergroup): void
     {
         array_push($this->usergroups, $usergroup);
     }
@@ -432,7 +432,7 @@ abstract class Item implements Serializable
     /**
      * @param array $usergroups Array of usergroup elements which should be added to the item.
      */
-    public function setAllUsergroups(array $usergroups)
+    public function setAllUsergroups(array $usergroups): void
     {
         $this->usergroups = $usergroups;
     }

--- a/src/FINDOLOGIC/Export/Data/Item.php
+++ b/src/FINDOLOGIC/Export/Data/Item.php
@@ -176,7 +176,7 @@ abstract class Item implements Serializable
         $this->price->setValue($price, $usergroup);
     }
 
-    public function getInsteadPrice(): float
+    public function getInsteadPrice()
     {
         return $this->insteadPrice;
     }
@@ -191,7 +191,7 @@ abstract class Item implements Serializable
         $this->insteadPrice = $insteadPrice;
     }
 
-    public function getMaxPrice(): float
+    public function getMaxPrice()
     {
         return $this->maxPrice;
     }
@@ -206,7 +206,7 @@ abstract class Item implements Serializable
         $this->maxPrice = $maxPrice;
     }
 
-    public function getTaxRate(): float
+    public function getTaxRate()
     {
         return $this->taxRate;
     }

--- a/src/FINDOLOGIC/Export/Data/Property.php
+++ b/src/FINDOLOGIC/Export/Data/Property.php
@@ -21,7 +21,10 @@ class Property
         "/ordernumber/"
     ];
 
+    /** @var string */
     private $key;
+
+    /** @var array */
     private $values;
 
     /**
@@ -43,7 +46,7 @@ class Property
         $this->setValues($values);
     }
 
-    public function getKey()
+    public function getKey(): string
     {
         return $this->key;
     }
@@ -55,7 +58,7 @@ class Property
      * @param string $value The value to add to the property element.
      * @param string|null $usergroup The usergroup of the property value.
      */
-    public function addValue(string $value, ?string $usergroup = null)
+    public function addValue(string $value, ?string $usergroup = null): void
     {
         if (array_key_exists($usergroup, $this->getAllValues())) {
             throw new DuplicateValueForUsergroupException($this->getKey(), $usergroup);
@@ -64,7 +67,7 @@ class Property
         $this->values[$usergroup] = DataHelper::checkForEmptyValue($value);
     }
 
-    protected function setValues(array $values)
+    protected function setValues(array $values): void
     {
         $this->values = [];
 
@@ -85,7 +88,7 @@ class Property
         }
     }
 
-    public function getAllValues()
+    public function getAllValues(): array
     {
         return $this->values;
     }

--- a/src/FINDOLOGIC/Export/Data/SalesFrequency.php
+++ b/src/FINDOLOGIC/Export/Data/SalesFrequency.php
@@ -13,7 +13,7 @@ class SalesFrequency extends UsergroupAwareSimpleValue
         parent::__construct('salesFrequencies', 'salesFrequency');
     }
 
-    protected function validate($value)
+    protected function validate($value): int
     {
         if ($value === '') {
             throw new EmptyValueNotAllowedException();

--- a/src/FINDOLOGIC/Export/Data/Sort.php
+++ b/src/FINDOLOGIC/Export/Data/Sort.php
@@ -13,7 +13,7 @@ class Sort extends UsergroupAwareSimpleValue
         parent::__construct('sorts', 'sort');
     }
 
-    protected function validate($value)
+    protected function validate($value): int
     {
         if ($value === '') {
             throw new EmptyValueNotAllowedException();

--- a/src/FINDOLOGIC/Export/Data/Url.php
+++ b/src/FINDOLOGIC/Export/Data/Url.php
@@ -12,7 +12,7 @@ class Url extends UsergroupAwareSimpleValue
         parent::__construct('urls', 'url');
     }
 
-    public function getDomSubtree(\DOMDocument $document)
+    public function getDomSubtree(\DOMDocument $document): \DOMElement
     {
         foreach ($this->getValues() as $value) {
             DataHelper::validateUrl($value);

--- a/src/FINDOLOGIC/Export/Data/Usergroup.php
+++ b/src/FINDOLOGIC/Export/Data/Usergroup.php
@@ -16,7 +16,7 @@ class Usergroup implements Serializable
         $this->value = DataHelper::checkForEmptyValue($value);
     }
 
-    public function getValue()
+    public function getValue(): string
     {
         return $this->value;
     }
@@ -25,7 +25,7 @@ class Usergroup implements Serializable
      * @SuppressWarnings(PHPMD.StaticAccess)
      * @inheritdoc
      */
-    public function getDomSubtree(\DOMDocument $document)
+    public function getDomSubtree(\DOMDocument $document): \DOMElement
     {
         $usergroupElem = XMLHelper::createElementWithText($document, 'usergroup', $this->getValue());
 
@@ -35,12 +35,12 @@ class Usergroup implements Serializable
     /**
      * @inheritdoc
      */
-    public function getCsvFragment(array $availableProperties = [])
+    public function getCsvFragment(array $availableProperties = []): string
     {
         return $this->getValue();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getValue();
     }

--- a/src/FINDOLOGIC/Export/Exporter.php
+++ b/src/FINDOLOGIC/Export/Exporter.php
@@ -31,7 +31,7 @@ abstract class Exporter
      * @param array $csvProperties Properties/extra columns for CSV export. Has no effect for XML export.
      * @return Exporter The exporter for the desired output format.
      */
-    public static function create(int $type, int $itemsPerPage = 20, array $csvProperties = [])
+    public static function create(int $type, int $itemsPerPage = 20, array $csvProperties = []): Exporter
     {
         if ($itemsPerPage < 1) {
             throw new \InvalidArgumentException('At least one item must be exported per page.');
@@ -71,7 +71,7 @@ abstract class Exporter
      *      exporter.
      * @return string The items in serialized form.
      */
-    abstract public function serializeItems(array $items, int $start, int $count, int $total);
+    abstract public function serializeItems(array $items, int $start, int $count, int $total): string;
 
     /**
      * Like serializeItems(), but the output is written to filesystem instead of being returned.
@@ -88,7 +88,13 @@ abstract class Exporter
      *      exporter.
      * @return string Full path of the written file.
      */
-    abstract public function serializeItemsToFile(string $targetDirectory, array $items, int $start, int $count, int $total);
+    abstract public function serializeItemsToFile(
+        string $targetDirectory,
+        array $items,
+        int $start,
+        int $count,
+        int $total
+    ): string;
 
     /**
      * Creates an export format-specific item instance.
@@ -96,5 +102,5 @@ abstract class Exporter
      * @param string $id Unique ID of the item.
      * @return Item The newly generated item.
      */
-    abstract public function createItem($id);
+    abstract public function createItem($id): Item;
 }

--- a/src/FINDOLOGIC/Export/Helpers/DataHelper.php
+++ b/src/FINDOLOGIC/Export/Helpers/DataHelper.php
@@ -27,7 +27,7 @@ class DataHelper
      * @throws EmptyValueNotAllowedException If the value is empty.
      * @return string Returns the value if not empty.
      */
-    public static function checkForEmptyValue($value)
+    public static function checkForEmptyValue($value): string
     {
         $value = trim($value);
 
@@ -47,7 +47,7 @@ class DataHelper
      * @throws InvalidUrlException If the input is no url.
      * @return string Returns the url if valid.
      */
-    public static function validateUrl(string $url)
+    public static function validateUrl(string $url): string
     {
         if (!filter_var($url, FILTER_VALIDATE_URL) || !preg_match('/http[s]?:\/\/.*/', $url)) {
             throw new InvalidUrlException();
@@ -62,7 +62,7 @@ class DataHelper
      * @param string $propertyKey The property key to check.
      * @throw BadPropertyKeyException In case the property key contains dangerous characters.
      */
-    public static function checkForIllegalCsvPropertyKeys(string $propertyKey)
+    public static function checkForIllegalCsvPropertyKeys(string $propertyKey): void
     {
         if (strpos($propertyKey, "\t") !== false || strpos($propertyKey, "\n") !== false) {
             throw new BadPropertyKeyException($propertyKey);
@@ -73,7 +73,7 @@ class DataHelper
      * @param string $attributeName Attribute name to output in exception.
      * @param string $attributeValue Attribute value to check if it exceeds character limit.
      */
-    public static function checkAttributeValueNotExceedingCharacterLimit($attributeName, $attributeValue)
+    public static function checkAttributeValueNotExceedingCharacterLimit($attributeName, $attributeValue): void
     {
         if (mb_strlen($attributeValue) > self::CHARACTER_LIMIT) {
             throw new AttributeValueLengthException($attributeName, self::CHARACTER_LIMIT);

--- a/src/FINDOLOGIC/Export/Helpers/UsergroupAwareMultiValue.php
+++ b/src/FINDOLOGIC/Export/Helpers/UsergroupAwareMultiValue.php
@@ -10,9 +10,16 @@ namespace FINDOLOGIC\Export\Helpers;
  */
 abstract class UsergroupAwareMultiValue implements Serializable
 {
+    /** @var string */
     private $rootCollectionName;
+
+    /** @var string */
     private $usergroupCollectionName;
+
+    /** @var string */
     private $csvDelimiter;
+
+    /** @var array */
     protected $values = [];
 
     public function __construct($rootCollectionName, $usergroupCollectionName, $csvDelimiter)
@@ -25,7 +32,7 @@ abstract class UsergroupAwareMultiValue implements Serializable
     /**
      * @param UsergroupAwareMultiValueItem $value The element to add the the collection.
      */
-    public function addValue(UsergroupAwareMultiValueItem $value)
+    public function addValue(UsergroupAwareMultiValueItem $value): void
     {
         if (!array_key_exists($value->getUsergroup(), $this->getValues())) {
             $this->values[$value->getUsergroup()] = [];
@@ -37,7 +44,7 @@ abstract class UsergroupAwareMultiValue implements Serializable
     /**
      * @param array $values Array of elements to be added to the collection.
      */
-    public function setAllValues(array $values)
+    public function setAllValues(array $values): void
     {
         $this->values = [];
 
@@ -47,7 +54,7 @@ abstract class UsergroupAwareMultiValue implements Serializable
         }
     }
 
-    public function getValues()
+    public function getValues(): array
     {
         return $this->values;
     }
@@ -56,7 +63,7 @@ abstract class UsergroupAwareMultiValue implements Serializable
      * @SuppressWarnings(PHPMD.StaticAccess)
      * @inheritdoc
      */
-    public function getDomSubtree(\DOMDocument $document)
+    public function getDomSubtree(\DOMDocument $document): \DOMElement
     {
         $rootCollectionElem = XMLHelper::createElement($document, $this->rootCollectionName);
 

--- a/src/FINDOLOGIC/Export/Helpers/UsergroupAwareMultiValueItem.php
+++ b/src/FINDOLOGIC/Export/Helpers/UsergroupAwareMultiValueItem.php
@@ -13,8 +13,13 @@ namespace FINDOLOGIC\Export\Helpers;
  */
 abstract class UsergroupAwareMultiValueItem implements Serializable
 {
+    /** @var string */
     private $itemName;
+
+    /** @var string */
     private $value;
+
+    /** @var string */
     private $usergroup;
 
     /**
@@ -27,12 +32,12 @@ abstract class UsergroupAwareMultiValueItem implements Serializable
         $this->usergroup = $usergroup;
     }
 
-    public function getValue()
+    public function getValue(): string
     {
         return $this->value;
     }
 
-    public function getUsergroup()
+    public function getUsergroup(): string
     {
         return $this->usergroup;
     }
@@ -41,7 +46,7 @@ abstract class UsergroupAwareMultiValueItem implements Serializable
      * @SuppressWarnings(PHPMD.StaticAccess)
      * @inheritdoc
      */
-    public function getDomSubtree(\DOMDocument $document)
+    public function getDomSubtree(\DOMDocument $document): \DOMElement
     {
         $valueElem = XMLHelper::createElementWithText($document, $this->itemName, $this->getValue());
 
@@ -51,7 +56,7 @@ abstract class UsergroupAwareMultiValueItem implements Serializable
     /**
      * @inheritdoc
      */
-    public function getCsvFragment(array $availableProperties = [])
+    public function getCsvFragment(array $availableProperties = []): string
     {
         return $this->getValue();
     }

--- a/src/FINDOLOGIC/Export/Helpers/UsergroupAwareSimpleValue.php
+++ b/src/FINDOLOGIC/Export/Helpers/UsergroupAwareSimpleValue.php
@@ -12,8 +12,13 @@ use FINDOLOGIC\Export\Exceptions\EmptyValueNotAllowedException;
  */
 abstract class UsergroupAwareSimpleValue implements Serializable
 {
+    /** @var string */
     private $collectionName;
+
+    /** @var string */
     private $itemName;
+
+    /** @var array */
     protected $values = [];
 
     public function __construct($collectionName, $itemName)
@@ -22,7 +27,7 @@ abstract class UsergroupAwareSimpleValue implements Serializable
         $this->itemName = $itemName;
     }
 
-    public function getValues()
+    public function getValues(): array
     {
         return $this->values;
     }
@@ -32,7 +37,7 @@ abstract class UsergroupAwareSimpleValue implements Serializable
      * @param string|int|float $value The value of the element.
      * @param string $usergroup The usergroup of the element.
      */
-    public function setValue($value, string $usergroup = '')
+    public function setValue($value, string $usergroup = ''): void
     {
         $this->values[$usergroup] = $this->validate($value);
     }
@@ -46,7 +51,7 @@ abstract class UsergroupAwareSimpleValue implements Serializable
      * When not valid an exception is thrown.
      *
      * @param string|int $value Validated value.
-     * @return string string|int
+     * @return string
      * @throws EmptyValueNotAllowedException
      */
     protected function validate($value)
@@ -64,7 +69,7 @@ abstract class UsergroupAwareSimpleValue implements Serializable
      * @SuppressWarnings(PHPMD.StaticAccess)
      * @inheritdoc
      */
-    public function getDomSubtree(\DOMDocument $document)
+    public function getDomSubtree(\DOMDocument $document): \DOMElement
     {
         $collectionElem = XMLHelper::createElement($document, $this->collectionName);
 
@@ -83,7 +88,7 @@ abstract class UsergroupAwareSimpleValue implements Serializable
     /**
      * @inheritdoc
      */
-    public function getCsvFragment(array $availableProperties = [])
+    public function getCsvFragment(array $availableProperties = []): string
     {
         $value = '';
 

--- a/src/FINDOLOGIC/Export/Helpers/XMLHelper.php
+++ b/src/FINDOLOGIC/Export/Helpers/XMLHelper.php
@@ -12,7 +12,7 @@ class XMLHelper
      * @param array $attributes String-to-string mapping of attributes to set on the element.
      * @return \DOMElement The newly constructed independent DOM element.
      */
-    public static function createElement(\DOMDocument $document, $name, array $attributes = [])
+    public static function createElement(\DOMDocument $document, $name, array $attributes = []): \DOMElement
     {
         $element = $document->createElement($name);
 
@@ -32,8 +32,12 @@ class XMLHelper
      * @param array $attributes String-to-string mapping of attributes to set on the element.
      * @return \DOMElement The newly constructed independent DOM element.
      */
-    public static function createElementWithText(\DOMDocument $document, $name, $text, array $attributes = [])
-    {
+    public static function createElementWithText(
+        \DOMDocument $document,
+        string $name,
+        string $text,
+        array $attributes = []
+    ): \DOMElement {
         $element = self::createElement($document, $name, $attributes);
         $wrappedText = $document->createCDATASection($text);
         $element->appendChild($wrappedText);

--- a/src/FINDOLOGIC/Export/XML/Page.php
+++ b/src/FINDOLOGIC/Export/XML/Page.php
@@ -20,12 +20,12 @@ class Page
         $this->items = [];
     }
 
-    public function addItem(XMLItem $item)
+    public function addItem(XMLItem $item): void
     {
         array_push($this->items, $item);
     }
 
-    public function setAllItems(array $items)
+    public function setAllItems(array $items): void
     {
         $this->items = [];
 
@@ -37,7 +37,7 @@ class Page
     /**
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    public function getXml()
+    public function getXml(): \DOMDocument
     {
         if (count($this->items) > $this->count) {
             throw new ItemsExceedCountValueException();

--- a/src/FINDOLOGIC/Export/XML/XMLExporter.php
+++ b/src/FINDOLOGIC/Export/XML/XMLExporter.php
@@ -2,6 +2,7 @@
 
 namespace FINDOLOGIC\Export\XML;
 
+use FINDOLOGIC\Export\Data\Item;
 use FINDOLOGIC\Export\Exporter;
 
 class XMLExporter extends Exporter
@@ -9,7 +10,7 @@ class XMLExporter extends Exporter
     /**
      * @inheritdoc
      */
-    public function serializeItems(array $items, int $start, int $count, int $total)
+    public function serializeItems(array $items, int $start, int $count, int $total): string
     {
         $page = new Page($start, $count, $total);
         $page->setAllItems($items);
@@ -21,8 +22,13 @@ class XMLExporter extends Exporter
     /**
      * @inheritdoc
      */
-    public function serializeItemsToFile(string $targetDirectory, array $items, int $start, int $count, int $total)
-    {
+    public function serializeItemsToFile(
+        string $targetDirectory,
+        array $items,
+        int $start,
+        int $count,
+        int $total
+    ): string {
         $xmlString = $this->serializeItems($items, $start, $count, $total);
         $targetPath = sprintf('%s/findologic_%d_%d.xml', $targetDirectory, $start, $count);
 
@@ -34,7 +40,7 @@ class XMLExporter extends Exporter
     /**
      * @inheritdoc
      */
-    public function createItem($id)
+    public function createItem($id): Item
     {
         return new XMLItem($id);
     }

--- a/src/FINDOLOGIC/Export/XML/XMLItem.php
+++ b/src/FINDOLOGIC/Export/XML/XMLItem.php
@@ -16,7 +16,7 @@ class XMLItem extends Item
     /**
      * @inheritdoc
      */
-    public function getCsvFragment(array $availableProperties = [])
+    public function getCsvFragment(array $availableProperties = []): void
     {
         throw new \BadMethodCallException('XMLItem does not implement CSV export.');
     }
@@ -25,7 +25,7 @@ class XMLItem extends Item
      * @SuppressWarnings(PHPMD.StaticAccess)
      * @inheritdoc
      */
-    public function getDomSubtree(\DOMDocument $document)
+    public function getDomSubtree(\DOMDocument $document): \DOMElement
     {
         $itemElem = XMLHelper::createElement($document, 'item', ['id' => $this->id]);
         $document->appendChild($itemElem);
@@ -53,7 +53,7 @@ class XMLItem extends Item
     /**
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    private function buildProperties(\DOMDocument $document)
+    private function buildProperties(\DOMDocument $document): \DOMElement
     {
         $allProps = XMLHelper::createElement($document, 'allProperties');
 
@@ -82,7 +82,7 @@ class XMLItem extends Item
     /**
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    private function buildAttributes(\DOMDocument $document)
+    private function buildAttributes(\DOMDocument $document): \DOMElement
     {
         $allAttributes = XMLHelper::createElement($document, 'allAttributes');
 
@@ -103,7 +103,7 @@ class XMLItem extends Item
     /**
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    private function buildImages(\DOMDocument $document)
+    private function buildImages(\DOMDocument $document): \DOMElement
     {
         $allImagesElem = XMLHelper::createElement($document, 'allImages');
 
@@ -135,7 +135,7 @@ class XMLItem extends Item
     /**
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    private function buildUsergroups(\DOMDocument $document)
+    private function buildUsergroups(\DOMDocument $document): \DOMElement
     {
         $usergroups = XMLHelper::createElement($document, 'usergroups');
 
@@ -153,7 +153,7 @@ class XMLItem extends Item
      * @param array $images The images to validate.
      * @return boolean Whether the images are valid or not.
      */
-    private function validateImages(array $images)
+    private function validateImages(array $images): bool
     {
         $valid = false;
 
@@ -171,32 +171,32 @@ class XMLItem extends Item
         return $valid;
     }
 
-    public function getInsteadPrice()
+    public function getInsteadPrice(): void
     {
         throw new UnsupportedValueException('insteadPrice');
     }
 
-    public function setInsteadPrice(float $insteadPrice)
+    public function setInsteadPrice(float $insteadPrice): void
     {
         throw new UnsupportedValueException('insteadPrice');
     }
 
-    public function getMaxPrice()
+    public function getMaxPrice(): void
     {
         throw new UnsupportedValueException('maxPrice');
     }
 
-    public function setMaxPrice(float $insteadPrice)
+    public function setMaxPrice(float $insteadPrice): void
     {
         throw new UnsupportedValueException('maxPrice');
     }
 
-    public function getTaxRate()
+    public function getTaxRate(): void
     {
         throw new UnsupportedValueException('taxRate');
     }
 
-    public function setTaxRate(float $insteadPrice)
+    public function setTaxRate(float $insteadPrice): void
     {
         throw new UnsupportedValueException('taxRate');
     }

--- a/tests/FINDOLOGIC/Export/Tests/CSVSerializationTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/CSVSerializationTest.php
@@ -8,6 +8,7 @@ use FINDOLOGIC\Export\Data\Bonus;
 use FINDOLOGIC\Export\Data\DateAdded;
 use FINDOLOGIC\Export\Data\Description;
 use FINDOLOGIC\Export\Data\Image;
+use FINDOLOGIC\Export\Data\Item;
 use FINDOLOGIC\Export\Data\Keyword;
 use FINDOLOGIC\Export\Data\Name;
 use FINDOLOGIC\Export\Data\Ordernumber;
@@ -19,13 +20,12 @@ use FINDOLOGIC\Export\Data\Summary;
 use FINDOLOGIC\Export\Data\Url;
 use FINDOLOGIC\Export\Data\Usergroup;
 use FINDOLOGIC\Export\Exporter;
-use FINDOLOGIC\Export\Exceptions\BadPropertyKeyException;
 use PHPUnit\Framework\TestCase;
 
 class CSVSerializationTest extends TestCase
 {
-    private const DEFAULT_CSV_HEADING = "id\tordernumber\tname\tsummary\tdescription\tprice\tinstead\tmaxprice\ttaxrate\t" .
-        "url\timage\tattributes\tkeywords\tgroups\tbonus\tsales_frequency\tdate_added\tsort";
+    private const DEFAULT_CSV_HEADING = "id\tordernumber\tname\tsummary\tdescription\tprice\tinstead\tmaxprice\t" .
+        "taxrate\turl\timage\tattributes\tkeywords\tgroups\tbonus\tsales_frequency\tdate_added\tsort";
 
     /** @var CSVExporter */
     private $exporter;
@@ -33,12 +33,12 @@ class CSVSerializationTest extends TestCase
     /**
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->exporter = Exporter::create(Exporter::TYPE_CSV);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         try {
             unlink('/tmp/findologic.csv');
@@ -47,7 +47,7 @@ class CSVSerializationTest extends TestCase
         }
     }
 
-    private function getMinimalItem($exporter = null)
+    private function getMinimalItem($exporter = null): Item
     {
         if ($exporter === null) {
             $exporter = $this->exporter;
@@ -94,7 +94,7 @@ class CSVSerializationTest extends TestCase
         return $item;
     }
 
-    public function testMinimalItemIsExported()
+    public function testMinimalItemIsExported(): void
     {
         $item = $this->getMinimalItem();
         $export = $this->exporter->serializeItems([$item]);
@@ -102,7 +102,7 @@ class CSVSerializationTest extends TestCase
         $this->assertInternalType('string', $export);
     }
 
-    public function testHeadingIsOnlyWrittenForFirstPage()
+    public function testHeadingIsOnlyWrittenForFirstPage(): void
     {
         $item = $this->getMinimalItem();
         $export = $this->exporter->serializeItems([$item], 0, 1, 2);
@@ -115,7 +115,7 @@ class CSVSerializationTest extends TestCase
         $this->assertNotContains(self::DEFAULT_CSV_HEADING, $export);
     }
 
-    public function testCsvCanBeWrittenDirectlyToFile()
+    public function testCsvCanBeWrittenDirectlyToFile(): void
     {
         $item = $this->getMinimalItem();
 
@@ -125,7 +125,7 @@ class CSVSerializationTest extends TestCase
         self::assertEquals($expectedCsvContent, file_get_contents('/tmp/findologic.csv'));
     }
 
-    public function testKitchenSink()
+    public function testKitchenSink(): void
     {
         $expectedId = '123';
         $expectedOrdernumbers = ['987654321', 'BAC-123'];
@@ -231,7 +231,7 @@ class CSVSerializationTest extends TestCase
         $this->assertEquals($expectedCsvLine, $item->getCsvFragment($expectedPropertyKeys));
     }
 
-    public function testItemsCanHaveVaryingProperties()
+    public function testItemsCanHaveVaryingProperties(): void
     {
         $firstPropertyName = 'only first item';
         $secondPropertyName = 'all items';
@@ -270,7 +270,7 @@ class CSVSerializationTest extends TestCase
         $this->assertEquals($expectedCsvHeading, $lines[0]);
     }
 
-    public function illegalPropertyProvider()
+    public function illegalPropertyProvider(): array
     {
         return [
             'tab' => [new Property("This\tcontains\ttabs", [null => 'some value'])],
@@ -284,7 +284,7 @@ class CSVSerializationTest extends TestCase
      *
      * @param Property $property The property with an illegal key to test.
      */
-    public function testFormatBreakingCharactersAreNotAllowedInPropertyKeys(Property $property)
+    public function testFormatBreakingCharactersAreNotAllowedInPropertyKeys(Property $property): void
     {
         $exporter = Exporter::create(
             Exporter::TYPE_CSV,
@@ -301,7 +301,7 @@ class CSVSerializationTest extends TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testSettingMoreThanOneImagePerItemCausesException()
+    public function testSettingMoreThanOneImagePerItemCausesException(): void
     {
         $item = $this->getMinimalItem();
         $item->addImage(new Image('https://example.org/some_image.png', Image::TYPE_DEFAULT));
@@ -313,12 +313,12 @@ class CSVSerializationTest extends TestCase
     /**
      * @expectedException \BadMethodCallException
      */
-    public function testAttemptingToGetXmlVersionForACSVItemCausesAnException()
+    public function testAttemptingToGetXmlVersionForACSVItemCausesAnException(): void
     {
         $this->getMinimalItem()->getDomSubtree(new \DOMDocument());
     }
 
-    public function testAddingRelativeUrlIsNotCausingAnException()
+    public function testAddingRelativeUrlIsNotCausingAnException(): void
     {
         $imageWithRelativePath = '/media/images/image.jpg';
         $image = new Image($imageWithRelativePath);
@@ -332,7 +332,7 @@ class CSVSerializationTest extends TestCase
      *
      * @return array Scenarios with value, the element class and the elements setter method name.
      */
-    public function csvSanitizedElementsInputProvider()
+    public function csvSanitizedElementsInputProvider(): array
     {
         return [
             'Ordernumber with invalid characters' => ["ordernumber\t\n", Ordernumber::class, 'addOrdernumber'],
@@ -351,7 +351,7 @@ class CSVSerializationTest extends TestCase
      * @param string $elementType
      * @param string $setterMethodName
      */
-    public function testSanitizingOfElementsWorks($value = '', $elementType = '', $setterMethodName = '')
+    public function testSanitizingOfElementsWorks($value = '', $elementType = '', $setterMethodName = ''): void
     {
         $item = $this->getMinimalItem();
 

--- a/tests/FINDOLOGIC/Export/Tests/DataElementsTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/DataElementsTest.php
@@ -30,7 +30,7 @@ class DataElementsTest extends TestCase
      *
      * @return array Scenarios with a value, the element class and whether this input should cause an exception.
      */
-    public function multiValueItemProvider()
+    public function multiValueItemProvider(): array
     {
         return [
             'Keyword with empty value' => ['', Keyword::class, true],
@@ -50,7 +50,7 @@ class DataElementsTest extends TestCase
         string $value = '',
         string $elementType = '',
         bool $shouldCauseException = true
-    ) {
+    ): void {
         try {
             $element = new $elementType($value);
             if ($shouldCauseException) {
@@ -72,7 +72,7 @@ class DataElementsTest extends TestCase
      * @return array Scenarios with a value, the element class and the expected exception, or null if none is supposed
      *      to be thrown.
      */
-    public function simpleValueItemProvider()
+    public function simpleValueItemProvider(): array
     {
         return [
             'Bonus with empty value' => ['', Bonus::class, EmptyValueNotAllowedException::class],
@@ -114,7 +114,7 @@ class DataElementsTest extends TestCase
         $value,
         string $elementType,
         ?string $expectedException = null
-    ) {
+    ): void {
         try {
             $element = new $elementType();
             $element->setValue($value);
@@ -133,7 +133,7 @@ class DataElementsTest extends TestCase
     /**
      * @expectedException \BadMethodCallException
      */
-    public function testCallingSetValueMethodOfDateAddedClassCausesException()
+    public function testCallingSetValueMethodOfDateAddedClassCausesException(): void
     {
         $element = new DateAdded();
         $element->setValue("");
@@ -145,7 +145,7 @@ class DataElementsTest extends TestCase
      * @return array Scenarios with key, one or more values, the element class and whether this input should cause
      *      an exception.
      */
-    public function emptyValueProvider()
+    public function emptyValueProvider(): array
     {
         return [
             'Attribute with empty key' => ['', ['value'], Attribute::class, true],
@@ -169,7 +169,7 @@ class DataElementsTest extends TestCase
         array $value,
         string $elementType,
         bool $shouldCauseException
-    ) {
+    ): void {
         try {
             $element = new $elementType($key, $value);
             if ($shouldCauseException) {
@@ -187,12 +187,12 @@ class DataElementsTest extends TestCase
     /**
      * @expectedException \FINDOLOGIC\Export\Exceptions\EmptyValueNotAllowedException
      */
-    public function testAddingEmptyUsergroupCausesException()
+    public function testAddingEmptyUsergroupCausesException(): void
     {
-        new Usergroup('');
+        $usergroup = new Usergroup('');
     }
 
-    public function testUsergroupStringRepresentationIsTheUsergroupValue()
+    public function testUsergroupStringRepresentationIsTheUsergroupValue(): void
     {
         $usergroup = new Usergroup('test');
 
@@ -202,7 +202,7 @@ class DataElementsTest extends TestCase
     /**
      * @expectedException \FINDOLOGIC\Export\Exceptions\AttributeValueLengthException
      */
-    public function testVeryLongAttributeValueCausesException()
+    public function testVeryLongAttributeValueCausesException(): void
     {
         $attribute = new Attribute('attribute_with_very_long_value');
 

--- a/tests/FINDOLOGIC/Export/Tests/DataHelperTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/DataHelperTest.php
@@ -17,7 +17,7 @@ class DataHelperTest extends TestCase
      * @param string|int $value Value that should be checked.
      * @param bool $shouldCauseException Whether the value should cause an exception or not.
      */
-    public function testEmptyValueDetectsEmptyStringsOnly($value, bool $shouldCauseException)
+    public function testEmptyValueDetectsEmptyStringsOnly($value, bool $shouldCauseException): void
     {
         try {
             $value = DataHelper::checkForEmptyValue($value);
@@ -43,7 +43,7 @@ class DataHelperTest extends TestCase
      *
      * @return array Cases with the value to check and whether it should cause a validation issue.
      */
-    public function emptyValueProvider()
+    public function emptyValueProvider(): array
     {
         return [
             'empty string' => ['', true],
@@ -63,7 +63,7 @@ class DataHelperTest extends TestCase
      * @param string|int|bool $value Value that should be checked.
      * @param bool $shouldCauseException Whether the value should cause an exception or not.
      */
-    public function testNumericValuesAreValidated($value, bool $shouldCauseException)
+    public function testNumericValuesAreValidated($value, bool $shouldCauseException): void
     {
         try {
             $numericValueElement = new UsergroupAwareNumericValue('dummies', 'dummy');
@@ -90,7 +90,7 @@ class DataHelperTest extends TestCase
      *
      * @return array Cases with the value to check and whether it should cause a validation issue.
      */
-    public function numericValueProvider()
+    public function numericValueProvider(): array
     {
         return [
             'string' => ['blubbergurke', true],
@@ -107,7 +107,7 @@ class DataHelperTest extends TestCase
      *
      * @expectedException \FINDOLOGIC\Export\Exceptions\AttributeValueLengthException
      */
-    public function testCharacterLimitCausesException()
+    public function testCharacterLimitCausesException(): void
     {
         $value = implode('', array_fill(0, 16384, '©'));
 

--- a/tests/FINDOLOGIC/Export/Tests/ExporterTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/ExporterTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class ExporterTest extends TestCase
 {
-    public function testItemsPerPageMustBeGreaterThanZero()
+    public function testItemsPerPageMustBeGreaterThanZero(): void
     {
         try {
             Exporter::create(Exporter::TYPE_XML, 0);
@@ -17,7 +17,7 @@ class ExporterTest extends TestCase
         }
     }
 
-    public function testUnknownExporterTypeMustThrowException()
+    public function testUnknownExporterTypeMustThrowException(): void
     {
         try {
             Exporter::create(123, 20);
@@ -27,7 +27,7 @@ class ExporterTest extends TestCase
         }
     }
 
-    public function testCsvHeadingIsNotWrittenToOutputWhenStartIsNonZero()
+    public function testCsvHeadingIsNotWrittenToOutputWhenStartIsNonZero(): void
     {
         $exporter = Exporter::create(Exporter::TYPE_CSV);
 

--- a/tests/FINDOLOGIC/Export/Tests/ItemTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/ItemTest.php
@@ -3,6 +3,7 @@
 namespace FINDOLOGIC\Export\Tests;
 
 use FINDOLOGIC\Export\Data\Attribute;
+use FINDOLOGIC\Export\Data\Item;
 use FINDOLOGIC\Export\Exceptions\EmptyElementsNotAllowedException;
 use FINDOLOGIC\Export\Data\Price;
 use FINDOLOGIC\Export\Data\Property;
@@ -19,12 +20,12 @@ class ItemTest extends TestCase
     /**
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->exporter = Exporter::create(Exporter::TYPE_XML);
     }
 
-    private function getMinimalItem()
+    private function getMinimalItem(): Item
     {
         $item = $this->exporter->createItem('123');
 
@@ -35,7 +36,7 @@ class ItemTest extends TestCase
         return $item;
     }
 
-    public function testAddingEmptyAttributesCauseException()
+    public function testAddingEmptyAttributesCauseException(): void
     {
         try {
             $item = $this->getMinimalItem();
@@ -49,7 +50,7 @@ class ItemTest extends TestCase
         }
     }
 
-    public function testAddingEmptyPropertiesCauseException()
+    public function testAddingEmptyPropertiesCauseException(): void
     {
         try {
             $item = $this->getMinimalItem();

--- a/tests/FINDOLOGIC/Export/Tests/PropertyTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/PropertyTest.php
@@ -10,7 +10,7 @@ class PropertyTest extends TestCase
     /**
      * @expectedException \FINDOLOGIC\Export\Exceptions\DuplicateValueForUsergroupException
      */
-    public function testAddingMultipleValuesPerUsergroupCausesException()
+    public function testAddingMultipleValuesPerUsergroupCausesException(): void
     {
         $property = new Property('prop');
         $property->addValue('foobar', 'usergroup');
@@ -20,14 +20,14 @@ class PropertyTest extends TestCase
     /**
      * @expectedException \FINDOLOGIC\Export\Exceptions\DuplicateValueForUsergroupException
      */
-    public function testAddingMultipleValuesWithoutUsergroupCausesException()
+    public function testAddingMultipleValuesWithoutUsergroupCausesException(): void
     {
         $property = new Property('prop');
         $property->addValue('foobar');
         $property->addValue('foobar');
     }
 
-    public function propertyKeyProvider()
+    public function propertyKeyProvider(): array
     {
         return [
             'reserved property "image\d+"' => ['image0', true],
@@ -39,8 +39,10 @@ class PropertyTest extends TestCase
 
     /**
      * @dataProvider propertyKeyProvider
+     * @param string $key
+     * @param bool $shouldCauseException
      */
-    public function testReservedPropertyKeysCausesException($key, $shouldCauseException)
+    public function testReservedPropertyKeysCausesException(string $key, bool $shouldCauseException): void
     {
         try {
             $property = new Property($key);
@@ -56,7 +58,7 @@ class PropertyTest extends TestCase
         }
     }
 
-    public function testNonAssociativePropertyValueCausesException()
+    public function testNonAssociativePropertyValueCausesException(): void
     {
         try {
             $property = new Property('foo', ['bar']);

--- a/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
@@ -5,6 +5,7 @@ namespace FINDOLOGIC\Export\Tests;
 use DateTime;
 use FINDOLOGIC\Export\Data\Attribute;
 use FINDOLOGIC\Export\Data\Image;
+use FINDOLOGIC\Export\Data\Item;
 use FINDOLOGIC\Export\Data\Keyword;
 use FINDOLOGIC\Export\Data\Ordernumber;
 use FINDOLOGIC\Export\Data\Price;
@@ -36,7 +37,7 @@ class XmlSerializationTest extends TestCase
 
     private static $schema;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -44,7 +45,7 @@ class XmlSerializationTest extends TestCase
         self::$schema = file_get_contents(self::SCHEMA_URL);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         try {
             unlink('/tmp/findologic_0_1.xml');
@@ -59,12 +60,12 @@ class XmlSerializationTest extends TestCase
     /**
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->exporter = Exporter::create(Exporter::TYPE_XML);
     }
 
-    private function getMinimalItem()
+    private function getMinimalItem(): Item
     {
         $item = $this->exporter->createItem('123');
 
@@ -75,7 +76,7 @@ class XmlSerializationTest extends TestCase
         return $item;
     }
 
-    private function assertPageIsValid($xmlString)
+    private function assertPageIsValid($xmlString): void
     {
         $xmlDocument = new \DOMDocument('1.0', 'utf-8');
         $xmlDocument->loadXML($xmlString);
@@ -83,14 +84,14 @@ class XmlSerializationTest extends TestCase
         $this->assertTrue($xmlDocument->schemaValidateSource(self::$schema));
     }
 
-    public function testEmptyPageIsValid()
+    public function testEmptyPageIsValid(): void
     {
         $page = $this->exporter->serializeItems([], 0, 0, 0);
 
         $this->assertPageIsValid($page);
     }
 
-    public function testMinimalItemIsValid()
+    public function testMinimalItemIsValid(): void
     {
         $item = $this->getMinimalItem();
         $page = $this->exporter->serializeItems([$item], 0, 1, 1);
@@ -101,7 +102,7 @@ class XmlSerializationTest extends TestCase
     /**
      * @expectedException \FINDOLOGIC\Export\Exceptions\ItemsExceedCountValueException
      */
-    public function testMoreItemsSuppliedThanCountValueCausesException()
+    public function testMoreItemsSuppliedThanCountValueCausesException(): void
     {
         $items = [];
 
@@ -119,7 +120,7 @@ class XmlSerializationTest extends TestCase
         $this->exporter->serializeItems($items, 0, 1, 1);
     }
 
-    public function testPropertyKeysAndValuesAreCdataWrapped()
+    public function testPropertyKeysAndValuesAreCdataWrapped(): void
     {
         $item = $this->getMinimalItem();
 
@@ -131,7 +132,7 @@ class XmlSerializationTest extends TestCase
         $this->assertPageIsValid($page);
     }
 
-    public function testAttributesAreCdataWrapped()
+    public function testAttributesAreCdataWrapped(): void
     {
         $item = $this->getMinimalItem();
 
@@ -143,7 +144,7 @@ class XmlSerializationTest extends TestCase
         $this->assertPageIsValid($page);
     }
 
-    public function testImagesCanBeDefaultAndThumbnail()
+    public function testImagesCanBeDefaultAndThumbnail(): void
     {
         $item = $this->getMinimalItem();
 
@@ -158,7 +159,7 @@ class XmlSerializationTest extends TestCase
         $this->assertPageIsValid($page);
     }
 
-    public function testBaseImageCanBeExported()
+    public function testBaseImageCanBeExported(): void
     {
         $item = $this->getMinimalItem();
 
@@ -190,7 +191,7 @@ class XmlSerializationTest extends TestCase
     /**
      * @expectedException \FINDOLOGIC\Export\Exceptions\BaseImageMissingException
      */
-    public function testMissingBaseImageCausesException()
+    public function testMissingBaseImageCausesException(): void
     {
         $item = $this->getMinimalItem();
 
@@ -205,7 +206,7 @@ class XmlSerializationTest extends TestCase
     /**
      * @expectedException \FINDOLOGIC\Export\Exceptions\ImagesWithoutUsergroupMissingException
      */
-    public function testImagesWithoutUsergroupMissingCausesException()
+    public function testImagesWithoutUsergroupMissingCausesException(): void
     {
         $item = $this->getMinimalItem();
 
@@ -216,7 +217,7 @@ class XmlSerializationTest extends TestCase
         $this->exporter->serializeItems([$item], 0, 1, 1);
     }
 
-    public function testOrdernumbersSupportUsergroups()
+    public function testOrdernumbersSupportUsergroups(): void
     {
         $item = $this->getMinimalItem();
 
@@ -230,7 +231,7 @@ class XmlSerializationTest extends TestCase
         $this->assertPageIsValid($page);
     }
 
-    public function testKeywordsSupportUsergroups()
+    public function testKeywordsSupportUsergroups(): void
     {
         $item = $this->getMinimalItem();
 
@@ -244,7 +245,7 @@ class XmlSerializationTest extends TestCase
         $this->assertPageIsValid($page);
     }
 
-    public function testUsergroupVisibilitiesAreExported()
+    public function testUsergroupVisibilitiesAreExported(): void
     {
         $item = $this->getMinimalItem();
 
@@ -258,7 +259,7 @@ class XmlSerializationTest extends TestCase
         $this->assertPageIsValid($page);
     }
 
-    public function testXmlCanBeWrittenDirectlyToFile()
+    public function testXmlCanBeWrittenDirectlyToFile(): void
     {
         $item = $this->getMinimalItem();
 
@@ -268,7 +269,7 @@ class XmlSerializationTest extends TestCase
         self::assertEquals($expectedXml, file_get_contents('/tmp/findologic_0_1.xml'));
     }
 
-    public function testAttemptingToGetCsvFromAnXmlItemResultsInAnException()
+    public function testAttemptingToGetCsvFromAnXmlItemResultsInAnException(): void
     {
         $item = new XMLItem(123);
 
@@ -283,7 +284,7 @@ class XmlSerializationTest extends TestCase
      * @return array Name of add method to call in a test to add a certain value, and an array of values with
      *      usergroup names as key.
      */
-    public function simpleValueAddingShortcutProvider()
+    public function simpleValueAddingShortcutProvider(): array
     {
         $stringValuesWithUsergroupKeys = [
             '' => 'No usergroup',
@@ -323,7 +324,7 @@ class XmlSerializationTest extends TestCase
      * @param string $valueType
      * @param array $values
      */
-    public function testSimpleValuesAddedToItemViaShortcutAccumulate(string $valueType, array $values)
+    public function testSimpleValuesAddedToItemViaShortcutAccumulate(string $valueType, array $values): void
     {
         $item = new XMLItem(123);
 
@@ -334,7 +335,7 @@ class XmlSerializationTest extends TestCase
         $this->assertEquals($values, $item->{'get' . $valueType}()->getValues());
     }
 
-    public function testDateValuesAddedToItemViaShortcutAccumulate()
+    public function testDateValuesAddedToItemViaShortcutAccumulate(): void
     {
         $values = [
             '' => new DateTime('today midnight'),
@@ -361,7 +362,7 @@ class XmlSerializationTest extends TestCase
      *
      * @return array Scenarios with a value and the expected exception
      */
-    public function urlValidationProvider()
+    public function urlValidationProvider(): array
     {
         return [
             'Url with value' => ['value', InvalidUrlException::class],
@@ -379,7 +380,7 @@ class XmlSerializationTest extends TestCase
      * @param string $value
      * @param string $expectedException
      */
-    public function testUrlValidationWorks(string $value, string $expectedException)
+    public function testUrlValidationWorks(string $value, string $expectedException): void
     {
         try {
             $url =  new Url();
@@ -390,14 +391,14 @@ class XmlSerializationTest extends TestCase
         }
     }
 
-    public function testItemsCanBeAddedToXmlPageAsWell()
+    public function testItemsCanBeAddedToXmlPageAsWell(): void
     {
         $page = new Page(0, 1, 1);
         $page->addItem($this->getMinimalItem());
         $this->assertNotNull($page->getXml());
     }
 
-    public function unsupportedValueProvider()
+    public function unsupportedValueProvider(): array
     {
         return [
             'getInsteadPrice' => ['getInsteadPrice', null],
@@ -416,7 +417,7 @@ class XmlSerializationTest extends TestCase
      * @param string $method Name of the method to call to interact with an unsupported value.
      * @param float|null $parameter The parameter in case of a setter.
      */
-    public function testUsingValuesUnsupportedByXmlCauseExceptions(string $method, ?float $parameter)
+    public function testUsingValuesUnsupportedByXmlCauseExceptions(string $method, ?float $parameter): void
     {
         $item = $this->getMinimalItem();
 
@@ -427,7 +428,7 @@ class XmlSerializationTest extends TestCase
         }
     }
 
-    public function testAddingPropertyWithUsergroupWorksAsExpected()
+    public function testAddingPropertyWithUsergroupWorksAsExpected(): void
     {
         $item = $this->getMinimalItem();
 
@@ -441,13 +442,13 @@ class XmlSerializationTest extends TestCase
     /**
      * @expectedException \FINDOLOGIC\Export\Exceptions\InvalidUrlException
      */
-    public function testAddingInvalidUrlToImageElementCausesException()
+    public function testAddingInvalidUrlToImageElementCausesException(): void
     {
         $image = new Image('www.store.com/images/277KTL.png');
         $image->getDomSubtree(new \DOMDocument());
     }
 
-    public function testAddingUrlsToXmlDomWorksAsExpected()
+    public function testAddingUrlsToXmlDomWorksAsExpected(): void
     {
         $item = $this->getMinimalItem();
 


### PR DESCRIPTION
## Purpose

- Add PHP 7.x features, specifically return types, Issue #77 
- Updated composer file and set PHP version >= 7.1 as required

#### Open Questions and Pre-Merge TODOs

- [x] `composer lint` was executed.
- [x] Tests were written and pass with 100% coverage.
- [x] A issue with a detailed explanation of the problem/enhancement was created and linked.
