### PR TITLE
Require the xml export schema package as non dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,12 +5,12 @@
     "require": {
         "php": "^7.1",
         "ext-dom": "*",
-        "ext-mbstring": "*"
+        "ext-mbstring": "*",
+        "findologic/xml-export-schema": "^1.2"
     },
     "require-dev": {
         "phpunit/phpunit": ">7.5",
-        "squizlabs/php_codesniffer": "^3.4",
-        "findologic/xml-export-schema": "^1.1"
+        "squizlabs/php_codesniffer": "^3.4"
     },
     "scripts": {
         "lint": "phpcs",


### PR DESCRIPTION
## Purpose

This was overseen upon review with the last deployment. The constants from the xml export schema package is set as a dev dependency.
