### PR TITLE
FINDO-8146_Disallow_XML_exports_with_empty_names_via_schema

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": "^7.1",
         "ext-dom": "*",
         "ext-mbstring": "*",
-        "findologic/xml-export-schema": "dev-FINDO-8146_Disallow_XML_exports_with_empty_names_via_schema"
+        "findologic/xml-export-schema": "^1.3"
     },
     "require-dev": {
         "phpunit/phpunit": ">7.5",
@@ -46,11 +46,5 @@
         "psr-0": {
             "FINDOLOGIC\\Export\\Tests\\": "tests/"
         }
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/findologic/xml-export"
-        }
-    ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": "^7.1",
         "ext-dom": "*",
         "ext-mbstring": "*",
-        "findologic/xml-export-schema": "^1.2"
+        "findologic/xml-export-schema": "dev-FINDO-8146_Disallow_XML_exports_with_empty_names_via_schema"
     },
     "require-dev": {
         "phpunit/phpunit": ">7.5",
@@ -46,5 +46,11 @@
         "psr-0": {
             "FINDOLOGIC\\Export\\Tests\\": "tests/"
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/findologic/xml-export"
+        }
+    ]
 }


### PR DESCRIPTION
## Purpose

To use the newer version of xml-export `1.3`.

## Approach

Empty or missing name tag in any item will not be allowed anymore.

#### Open Questions and Pre-Merge TODOs

- [x] `composer lint` and `composer fix` was executed.
- [x] Tests were written and pass with 100% coverage.
- [x] A issue with a detailed explanation of the problem/enhancement was created and linked.
