### PR TITLE
Allow interface as dateadded

### DIFF
--- a/src/FINDOLOGIC/Export/Data/DateAdded.php
+++ b/src/FINDOLOGIC/Export/Data/DateAdded.php
@@ -3,7 +3,7 @@
 namespace FINDOLOGIC\Export\Data;
 
 use BadMethodCallException;
-use DateTime;
+use DateTimeInterface;
 use FINDOLOGIC\Export\Helpers\UsergroupAwareSimpleValue;
 
 class DateAdded extends UsergroupAwareSimpleValue
@@ -18,9 +18,9 @@ class DateAdded extends UsergroupAwareSimpleValue
         throw new BadMethodCallException('Assign DateAdded values by passing a \DateTime to setDateValue()');
     }
 
-    public function setDateValue(DateTime $value, string $usergroup = ''): void
+    public function setDateValue(DateTimeInterface $value, string $usergroup = ''): void
     {
-        $formatted = $value->format(DateTime::ATOM);
+        $formatted = $value->format(DateTimeInterface::ATOM);
 
         parent::setValue($formatted, $usergroup);
     }

--- a/src/FINDOLOGIC/Export/Data/DateAdded.php
+++ b/src/FINDOLOGIC/Export/Data/DateAdded.php
@@ -3,6 +3,7 @@
 namespace FINDOLOGIC\Export\Data;
 
 use BadMethodCallException;
+use DateTime;
 use DateTimeInterface;
 use FINDOLOGIC\Export\Helpers\UsergroupAwareSimpleValue;
 

--- a/src/FINDOLOGIC/Export/Data/DateAdded.php
+++ b/src/FINDOLOGIC/Export/Data/DateAdded.php
@@ -21,7 +21,7 @@ class DateAdded extends UsergroupAwareSimpleValue
 
     public function setDateValue(DateTimeInterface $value, string $usergroup = ''): void
     {
-        $formatted = $value->format(DateTimeInterface::ATOM);
+        $formatted = $value->format(DateTime::ATOM);
 
         parent::setValue($formatted, $usergroup);
     }

--- a/src/FINDOLOGIC/Export/Data/DateAdded.php
+++ b/src/FINDOLOGIC/Export/Data/DateAdded.php
@@ -16,7 +16,9 @@ class DateAdded extends UsergroupAwareSimpleValue
 
     public function setValue($value, string $usergroup = ''): void
     {
-        throw new BadMethodCallException('Assign DateAdded values by passing a \DateTime to setDateValue()');
+        throw new BadMethodCallException(
+            sprintf('Assign DateAdded values by passing a %s to setDateValue()', DateTimeInterface::class)
+        );
     }
 
     public function setDateValue(DateTimeInterface $value, string $usergroup = ''): void

--- a/src/FINDOLOGIC/Export/Data/Item.php
+++ b/src/FINDOLOGIC/Export/Data/Item.php
@@ -3,6 +3,7 @@
 namespace FINDOLOGIC\Export\Data;
 
 use DateTime;
+use DateTimeInterface;
 use DOMDocument;
 use FINDOLOGIC\Export\Exceptions\EmptyElementsNotAllowedException;
 use FINDOLOGIC\Export\Helpers\Serializable;
@@ -323,10 +324,10 @@ abstract class Item implements Serializable
     /**
      * Shortcut to easily add the date added value of the item.
      *
-     * @param DateTime $dateAdded The date on which the item was added to the ecommerce system.
+     * @param DateTimeInterface $dateAdded The date on which the item was added to the ecommerce system.
      * @param string $usergroup The usergroup of the date added value.
      */
-    public function addDateAdded(DateTime $dateAdded, string $usergroup = ''): void
+    public function addDateAdded(DateTimeInterface $dateAdded, string $usergroup = ''): void
     {
         $this->dateAdded->setDateValue($dateAdded, $usergroup);
     }

--- a/src/FINDOLOGIC/Export/Data/Item.php
+++ b/src/FINDOLOGIC/Export/Data/Item.php
@@ -2,7 +2,6 @@
 
 namespace FINDOLOGIC\Export\Data;
 
-use DateTime;
 use DateTimeInterface;
 use DOMDocument;
 use FINDOLOGIC\Export\Exceptions\EmptyElementsNotAllowedException;

--- a/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
@@ -4,6 +4,7 @@ namespace FINDOLOGIC\Export\Tests;
 
 use BadMethodCallException;
 use DateTime;
+use DateTimeImmutable;
 use DOMDocument;
 use DOMElement;
 use DOMXPath;
@@ -556,5 +557,22 @@ class XmlSerializationTest extends TestCase
         $item->setPrice($price);
 
         $this->exporter->serializeItems([$item], 0, 1, 1);
+    }
+
+    public function testDateTimesWhichExtendDateTimeInterfaceCanBeSetAsDateAdded(): void
+    {
+        $expectedDateTime = new DateTimeImmutable();
+        $expectedValue = $expectedDateTime->format(DateTime::ATOM);
+
+        /** @var XMLItem $item */
+        $item = $this->getMinimalItem();
+        $item->addDateAdded($expectedDateTime);
+
+        $page = new Page(0, 1, 1);
+        $page->addItem($item);
+        $document = $page->getXml();
+
+        $xpath = new DOMXPath($document);
+        $this->assertEquals($expectedValue, $xpath->query('//dateAdded')->item(0)->nodeValue);
     }
 }


### PR DESCRIPTION
## Purpose

If you have a custom `DateTime` object which extends from `\DateTimeInterface` you can not set a date value, as would result in a type error.

## Approach

Instead of requiring an instance of `\DateTime` for `\FINDOLOGIC\Export\Data\DateAdded::setDateValue`, just require an instance of `\DateTimeInterface`.

#### Open Questions and Pre-Merge TODOs

- [x] `composer lint` and `composer fix` was executed.
- [x] Tests were written and pass with 100% coverage.
- [x] ~A issue with a detailed explanation of the problem/enhancement was created and linked.~ Such a simple change does not require any issue.
