### PR TITLE
Add PHP 7.4 (snapshot) to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4snapshot
 
 install:
   - composer install


### PR DESCRIPTION
## Purpose

PHP 7.4 will arrive soon. Getting ready for it as soon as we can seems like a good idea.

## Approach

Extend the build matrix to run with PHP 7.4 and see what happens.

#### Open Questions and Pre-Merge TODOs

- [ ] ~~`composer lint` and `composer fix` was executed.~~ No code changes, only build config was updated.
- [ ] ~~Tests were written and pass with 100% coverage.~~ Build config "tested" as part of build process.
- [ ] ~~A issue with a detailed explanation of the problem/enhancement was created and linked.~~ Needless overhead for a simple change like this.
