### PR TITLE
Allow setting of "all" prices

### DIFF
--- a/src/FINDOLOGIC/Export/Data/Item.php
+++ b/src/FINDOLOGIC/Export/Data/Item.php
@@ -7,6 +7,7 @@ use DOMDocument;
 use FINDOLOGIC\Export\Exceptions\EmptyElementsNotAllowedException;
 use FINDOLOGIC\Export\Helpers\Serializable;
 use FINDOLOGIC\Export\Helpers\DataHelper;
+use InvalidArgumentException;
 
 abstract class Item implements Serializable
 {
@@ -194,6 +195,25 @@ abstract class Item implements Serializable
         }
 
         $this->price->setValue($price, $usergroup);
+    }
+
+    /**
+     * @param Price[] $prices
+     */
+    public function setAllPrices(array $prices): void
+    {
+        foreach ($prices as $price) {
+            if (!$price instanceof Price) {
+                throw new InvalidArgumentException(sprintf(
+                    'Given prices must be instances of %s',
+                    Price::class
+                ));
+            }
+
+            foreach ($price->getValues() as $usergroup => $value) {
+                $this->addPrice($value, $usergroup);
+            }
+        }
     }
 
     public function getInsteadPrice()


### PR DESCRIPTION
## Purpose

Right now you would need to go through all prices if you built them dynamically just to get the values and set them again like:

```php
/** @var Price[] $prices */
foreach ($prices as $price) {
    foreach ($price->getValues() as $usergroup => $priceValue) {
        $this->xmlItem->addPrice($priceValue, $usergroup);
    }
}
```

## Approach

Create method `\FINDOLOGIC\Export\Data\Item::setAllPrices` which allows setting an array of `Price`s. We already have methods for `setAllOrdernumbers` and `setAllImages` which allow easy setting of properties.

#### Open Questions and Pre-Merge TODOs

- [x] `composer lint` and `composer fix` was executed.
- [x] Tests were written and pass with 100% coverage.
- [x] ~A issue with a detailed explanation of the problem/enhancement was created and linked.~ Not really relevant.
