### PR TITLE
Adding multiple attributes with the same key should not override existing ones

### DIFF
--- a/src/FINDOLOGIC/Export/Data/Item.php
+++ b/src/FINDOLOGIC/Export/Data/Item.php
@@ -396,6 +396,17 @@ abstract class Item implements Serializable
     }
 
     /**
+     * Adds an attribute. If attributes with the same key, but a different value are added, they will not
+     * be overridden. E.g.
+     * ```
+     * $attr1 = Attribute('color', ['orange', 'yellow']);
+     * $attr2 = Attribute('color', ['pink', 'orange']);
+     *
+     * $item->addAttribute($attr1);
+     * $item->addAttribute($attr2);
+     * // $item attributes will be: ['orange', 'yellow', 'pink']
+     * ```
+     *
      * @param Attribute $attribute The attribute element to add to the item.
      */
     public function addAttribute(Attribute $attribute): void
@@ -404,7 +415,15 @@ abstract class Item implements Serializable
             throw new EmptyElementsNotAllowedException('Attribute', $attribute->getKey());
         }
 
-        $this->attributes[$attribute->getKey()] = $attribute;
+        if (!isset($this->attributes[$attribute->getKey()])) {
+            $this->attributes[$attribute->getKey()] = $attribute;
+            return;
+        }
+
+        $this->attributes[$attribute->getKey()] = new Attribute(
+            $attribute->getKey(),
+            array_unique(array_merge($this->attributes[$attribute->getKey()]->getValues(), $attribute->getValues()))
+        );
     }
 
     /**

--- a/src/FINDOLOGIC/Export/Data/Item.php
+++ b/src/FINDOLOGIC/Export/Data/Item.php
@@ -393,8 +393,34 @@ abstract class Item implements Serializable
     }
 
     /**
-     * Adds an attribute. If attributes with the same key, but a different value are added, they will not
-     * be overridden. E.g.
+     * Adds an attribute.
+     *
+     * E.g.
+     * ```
+     * $attr1 = Attribute('color', ['orange', 'yellow']);
+     * $attr2 = Attribute('color', ['pink', 'orange']);
+     *
+     * $item->addAttribute($attr1);
+     * $item->addAttribute($attr2);
+     * // $item attributes will be: ['pink', 'orange']
+     * ```
+     *
+     * @see addMergedAttribute if you want to merge values with the same key.
+     * @param Attribute $attribute The attribute element to add to the item.
+     */
+    public function addAttribute(Attribute $attribute): void
+    {
+        if (count($attribute->getValues()) === 0) {
+            throw new EmptyElementsNotAllowedException('Attribute', $attribute->getKey());
+        }
+
+        $this->attributes[$attribute->getKey()] = $attribute;
+    }
+
+    /**
+     * Adds an attribute by merging attribute values with the same key.
+     *
+     * E.g.
      * ```
      * $attr1 = Attribute('color', ['orange', 'yellow']);
      * $attr2 = Attribute('color', ['pink', 'orange']);
@@ -404,9 +430,9 @@ abstract class Item implements Serializable
      * // $item attributes will be: ['orange', 'yellow', 'pink']
      * ```
      *
-     * @param Attribute $attribute The attribute element to add to the item.
+     * @see addAttribute if you don't want to merge values with the same key.
      */
-    public function addAttribute(Attribute $attribute): void
+    public function addMergedAttribute(Attribute $attribute): void
     {
         if (count($attribute->getValues()) === 0) {
             throw new EmptyElementsNotAllowedException('Attribute', $attribute->getKey());

--- a/src/FINDOLOGIC/Export/Data/Item.php
+++ b/src/FINDOLOGIC/Export/Data/Item.php
@@ -385,9 +385,6 @@ abstract class Item implements Serializable
         }
 
         foreach ($property->getAllValues() as $usergroup => $value) {
-            if (!array_key_exists($usergroup, $this->properties)) {
-                $this->properties[$usergroup] = [];
-            }
             // No need to check if there are duplicate values for a single property and usergroup, because
             // Property::addValue() already takes care of that.
 

--- a/src/FINDOLOGIC/Export/XML/XMLItem.php
+++ b/src/FINDOLOGIC/Export/XML/XMLItem.php
@@ -100,13 +100,8 @@ class XMLItem extends Item
          * @var string $key
          * @var Attribute $attribute
          */
-        $addedAttributes = [];
         foreach ($this->attributes as $key => $attribute) {
-            if (!isset($addedAttributes[$key])) {
-                $addedAttributes[$key] = $attributes->appendChild($attribute->getDomSubtree($document));
-            } else {
-                $addedAttributes[$key]->appendChild($attribute->getDomSubtree($document));
-            }
+            $attributes->appendChild($attribute->getDomSubtree($document));
         }
 
         return $allAttributes;

--- a/src/FINDOLOGIC/Export/XML/XMLItem.php
+++ b/src/FINDOLOGIC/Export/XML/XMLItem.php
@@ -100,8 +100,13 @@ class XMLItem extends Item
          * @var string $key
          * @var Attribute $attribute
          */
+        $addedAttributes = [];
         foreach ($this->attributes as $key => $attribute) {
-            $attributes->appendChild($attribute->getDomSubtree($document));
+            if (!isset($addedAttributes[$key])) {
+                $addedAttributes[$key] = $attributes->appendChild($attribute->getDomSubtree($document));
+            } else {
+                $addedAttributes[$key]->appendChild($attribute->getDomSubtree($document));
+            }
         }
 
         return $allAttributes;

--- a/tests/FINDOLOGIC/Export/Tests/ItemTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/ItemTest.php
@@ -48,6 +48,18 @@ class ItemTest extends TestCase
         $item->addAttribute($attribute);
     }
 
+    public function testMergingEmptyAttributesCauseException(): void
+    {
+        $this->expectException(EmptyElementsNotAllowedException::class);
+        $this->expectExceptionMessage(
+            'Elements with empty values are not allowed. "Attribute" with the name "empty attribute"'
+        );
+
+        $item = $this->getMinimalItem();
+        $attribute = new Attribute('empty attribute', []);
+        $item->addMergedAttribute($attribute);
+    }
+
     public function testAddingEmptyPropertiesCauseException(): void
     {
         $this->expectException(EmptyElementsNotAllowedException::class);

--- a/tests/FINDOLOGIC/Export/Tests/ItemTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/ItemTest.php
@@ -38,28 +38,25 @@ class ItemTest extends TestCase
 
     public function testAddingEmptyAttributesCauseException(): void
     {
-        try {
-            $item = $this->getMinimalItem();
-            $attribute = new Attribute('empty attribute', []);
-            $item->addAttribute($attribute);
-            $this->fail('Assigning attributes with empty values should cause an exception!');
-        } catch (EmptyElementsNotAllowedException $e) {
-            $expectedMessage = 'Elements with empty values are not allowed. "Attribute" with the name ' .
-                '"empty attribute"';
-            $this->assertEquals($expectedMessage, $e->getMessage());
-        }
+        $this->expectException(EmptyElementsNotAllowedException::class);
+        $this->expectExceptionMessage(
+            'Elements with empty values are not allowed. "Attribute" with the name "empty attribute"'
+        );
+
+        $item = $this->getMinimalItem();
+        $attribute = new Attribute('empty attribute', []);
+        $item->addAttribute($attribute);
     }
 
     public function testAddingEmptyPropertiesCauseException(): void
     {
-        try {
-            $item = $this->getMinimalItem();
-            $property = new Property('empty property', []);
-            $item->addProperty($property);
-            $this->fail('Assigning properties with empty values should cause an exception!');
-        } catch (EmptyElementsNotAllowedException $e) {
-            $expectedMessage = 'Elements with empty values are not allowed. "Property" with the name "empty property"';
-            $this->assertEquals($expectedMessage, $e->getMessage());
-        }
+        $this->expectException(EmptyElementsNotAllowedException::class);
+        $this->expectExceptionMessage(
+            'Elements with empty values are not allowed. "Property" with the name "empty property"'
+        );
+
+        $item = $this->getMinimalItem();
+        $property = new Property('empty property', []);
+        $item->addProperty($property);
     }
 }

--- a/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
@@ -605,12 +605,39 @@ class XmlSerializationTest extends TestCase
         );
     }
 
-    public function testPricesAreNotInstancesOfPriceThrowsAnException()
+    public function testPricesAreNotInstancesOfPriceThrowsAnException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf('Given prices must be instances of %s', Price::class));
 
         $item = $this->exporter->createItem('123');
         $item->setAllPrices([new stdClass()]);
+    }
+
+    public function testAddingMultipleAttributesWillNotOverrideOldOnes(): void
+    {
+        /** @var XMLItem $item */
+        $item = $this->getMinimalItem();
+
+        $expectedAttributes = ['orange', 'yellow', 'pink'];
+        $attr1 = new Attribute('color', ['orange', 'yellow', 'yellow']);
+        $attr2 = new Attribute('color', ['pink', 'orange', 'pink']);
+
+        $item->addAttribute($attr1);
+        $item->addAttribute($attr2);
+
+        $page = new Page(0, 1, 1);
+        $page->addItem($item);
+        $document = $page->getXml();
+        $xpath = new DOMXPath($document);
+
+        $values = $xpath->query('//attribute')->item(0)->childNodes->item(1)->childNodes;
+
+        $actualAttributes = [];
+        for ($i = 0; $i < $values->length; $i++) {
+            $actualAttributes[] = $values->item($i)->nodeValue;
+        }
+
+        $this->assertEquals($expectedAttributes, $actualAttributes);
     }
 }

--- a/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
@@ -614,7 +614,7 @@ class XmlSerializationTest extends TestCase
         $item->setAllPrices([new stdClass()]);
     }
 
-    public function testAddingMultipleAttributesWillNotOverrideOldOnes(): void
+    public function testMergingAttributesWillNotOverrideExistingOnes(): void
     {
         /** @var XMLItem $item */
         $item = $this->getMinimalItem();
@@ -623,8 +623,8 @@ class XmlSerializationTest extends TestCase
         $attr1 = new Attribute('color', ['orange', 'yellow', 'yellow']);
         $attr2 = new Attribute('color', ['pink', 'orange', 'pink']);
 
-        $item->addAttribute($attr1);
-        $item->addAttribute($attr2);
+        $item->addMergedAttribute($attr1);
+        $item->addMergedAttribute($attr2);
 
         $page = new Page(0, 1, 1);
         $page->addItem($item);
@@ -634,8 +634,8 @@ class XmlSerializationTest extends TestCase
         $values = $xpath->query('//attribute')->item(0)->childNodes->item(1)->childNodes;
 
         $actualAttributes = [];
-        for ($i = 0; $i < $values->length; $i++) {
-            $actualAttributes[] = $values->item($i)->nodeValue;
+        foreach ($values as $value) {
+            $actualAttributes[] = $value->nodeValue;
         }
 
         $this->assertEquals($expectedAttributes, $actualAttributes);


### PR DESCRIPTION
## Purpose

Currently there are no getters for attributes. I also do not think it would be required, but it is probably not available for a reason.
This fix allows:
```php
$attr1 = new Attribute('color', ['orange', 'yellow']);
$attr2 = new Attribute('color', ['pink', 'orange', 'pink']);

$item->addMergedAttribute($attr1);
$item->addMergedAttribute($attr2);
// $item attributes will be: ['orange', 'yellow', 'pink']
```

Before this fix it would've resulted in:
```php
// $item attributes will be: ['pink', 'orange', 'pink']
```

## Approach

Check if the key exists and if it does, get all attribute values from the key, create a new `Attribute` instance and put them together. Also making sure no duplicates occur.

#### Open Questions and Pre-Merge TODOs

- [x] `composer lint` and `composer fix` was executed.
- [x] Tests were written and pass with 100% coverage.
- [x] ~~A issue with a detailed explanation of the problem/enhancement was created and linked.~~ Not necessary.
