### PR TITLE
Reduce release archive size by ignoring files and directories

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+* text=auto
+
+/.github export-ignore
+/examples export-ignore
+/tests export-ignore
+.codeclimate.yml export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+CONTRIBUTING.md export-ignore
+phpcs.xml.dist export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
## Purpose

The current archive is bloated with irrelevant package information for implementers.

This PR: 

- reduces archive size and
- helps to publish only the essentials of the library

## Approach

Add .gitattributes file with the excluded file paths.

#### Open Questions and Pre-Merge TODOs

- [x]  ~~`composer lint` and `composer fix` was executed.~~ No changes to the code!
- [x] ~~Tests were written and pass with 100% coverage.~~ No changes to the code!
- [x] ~~A issue with a detailed explanation of the problem/enhancement was created and linked.~~  See purpose and approach.
