### PR TITLE
add_required_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,16 @@ $exporter = Exporter::create(Exporter::TYPE_XML);
 
 $item = $exporter->createItem('123');
 
+$item->addName('Test');
+$item->addUrl('http://example.org/test.html');
 $item->addPrice(13.37);
 // Alternative long form:
+// $name = new Name();
+// $name->setValue('Test');
+// $item->setName($name);
+// $url = new Url();
+// $url->setValue('http://example.org/test.html');
+// $item->setUrl($url);
 // $price = new Price();
 // $price->setValue(13.37);
 // $item->setPrice($price);
@@ -91,7 +99,15 @@ $exporter = Exporter::create(Exporter::TYPE_CSV);
 $item = $exporter->createItem('123');
 
 $item->addPrice(13.37);
+$item->addName('Test');
+$item->addUrl('http://example.org/test.html');
 // Alternative long form:
+// $name = new Name();
+// $name->setValue('Test');
+// $item->setName($name);
+// $url = new Url();
+// $url->setValue('http://example.org/test.html');
+// $item->setUrl($url);
 // $price = new Price();
 // $price->setValue(13.37);
 // $item->setPrice($price);

--- a/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
@@ -79,6 +79,7 @@ class XmlSerializationTest extends TestCase
         $item = $this->exporter->createItem('123');
 
         $item->addName('Alternative name');
+        $item->addUrl('http://example.org/item.html');
 
         $price = new Price();
         $price->setValue('13.37');
@@ -591,6 +592,7 @@ class XmlSerializationTest extends TestCase
         $item = $this->exporter->createItem('123');
         $item->setAllPrices([$price, $anotherPrice]);
         $item->addName('Best item ever');
+        $item->addUrl('http://example.org/item.html');
 
         $page = new Page(0, 1, 1);
         $page->addItem($item);


### PR DESCRIPTION
## Purpose

* The XML export schema was extended to require a URL to be set.
* This could be considered a compatibility break, but URLs were de-facto required before the schema was changed to reflect that, so this is more of a bug fix.

## Approach

* [x] Add URL to the minimal examples.
* [x] Add URL to the tests failing due to the XML schema change.

#### Open Questions and Pre-Merge TODOs

- [x] `composer lint` and `composer fix` was executed.
- [x] Tests were written and pass with 100% coverage.
- [ ] ~~A issue with a detailed explanation of the problem/enhancement was created and linked.~~
