### PR TITLE
Add URL in exception message for easier debugging

### DIFF
--- a/src/FINDOLOGIC/Export/Exceptions/InvalidUrlException.php
+++ b/src/FINDOLOGIC/Export/Exceptions/InvalidUrlException.php
@@ -6,8 +6,8 @@ use RuntimeException;
 
 class InvalidUrlException extends RuntimeException
 {
-    public function __construct()
+    public function __construct(string $url)
     {
-        parent::__construct('Value is not a valid url!');
+        parent::__construct(sprintf('"%s" is not a valid url!', $url));
     }
 }

--- a/src/FINDOLOGIC/Export/Helpers/DataHelper.php
+++ b/src/FINDOLOGIC/Export/Helpers/DataHelper.php
@@ -68,7 +68,7 @@ class DataHelper
     public static function validateUrl(string $url): string
     {
         if (!filter_var($url, FILTER_VALIDATE_URL) || !preg_match('/http[s]?:\/\/.*/', $url)) {
-            throw new InvalidUrlException();
+            throw new InvalidUrlException($url);
         }
 
         return $url;

--- a/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
@@ -469,9 +469,10 @@ class XmlSerializationTest extends TestCase
         $image->getDomSubtree(new DOMDocument());
     }
 
-    public function testAddingImproperEncodedUrlToImageElementCausesException(): void
+    public function testAddingImproperlyEncodedUrlToImageElementCausesException(): void
     {
         $this->expectException(InvalidUrlException::class);
+        $this->expectExceptionMessage('"https://store.com/Alu-Style-Ø-270-cm50324901e845e.jpg" is not a valid url!');
 
         $image = new Image('https://store.com/Alu-Style-Ø-270-cm50324901e845e.jpg');
         $image->getDomSubtree(new DOMDocument());

--- a/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
@@ -469,6 +469,14 @@ class XmlSerializationTest extends TestCase
         $image->getDomSubtree(new DOMDocument());
     }
 
+    public function testAddingImproperEncodedUrlToImageElementCausesException(): void
+    {
+        $this->expectException(InvalidUrlException::class);
+
+        $image = new Image('https://store.com/Alu-Style-Ø-270-cm50324901e845e.jpg');
+        $image->getDomSubtree(new DOMDocument());
+    }
+
     public function testAddingUrlsToXmlDomWorksAsExpected(): void
     {
         $item = $this->getMinimalItem();


### PR DESCRIPTION
## Purpose

Show URL in exception message for easier debugging

## Approach

Currently we are not able to identify which URL is invalid from the exception message.

#### Open Questions and Pre-Merge TODOs

- [x] `composer lint` and `composer fix` was executed.
- [x] Tests were written and pass with 100% coverage.
- [ ] A issue with a detailed explanation of the problem/enhancement was created and linked.
