### PR TITLE
Fix flaw in pagination for CSV file serialization

### DIFF
--- a/src/FINDOLOGIC/Export/CSV/CSVExporter.php
+++ b/src/FINDOLOGIC/Export/CSV/CSVExporter.php
@@ -56,7 +56,7 @@ class CSVExporter extends Exporter
         $csvString = $this->serializeItems($items, $start, $count, $total);
         $targetPath = sprintf('%s/findologic.csv', $targetDirectory);
 
-        file_put_contents($targetPath, $csvString);
+        file_put_contents($targetPath, $csvString, FILE_APPEND);
 
         return $targetPath;
     }

--- a/src/FINDOLOGIC/Export/CSV/CSVExporter.php
+++ b/src/FINDOLOGIC/Export/CSV/CSVExporter.php
@@ -56,7 +56,8 @@ class CSVExporter extends Exporter
         $csvString = $this->serializeItems($items, $start, $count, $total);
         $targetPath = sprintf('%s/findologic.csv', $targetDirectory);
 
-        file_put_contents($targetPath, $csvString, FILE_APPEND);
+        // Clear CSV contents if a new export starts with start 0. Otherwise append the contents.
+        file_put_contents($targetPath, $csvString, $start > 0 ? FILE_APPEND : 0);
 
         return $targetPath;
     }

--- a/src/FINDOLOGIC/Export/CSV/CSVExporter.php
+++ b/src/FINDOLOGIC/Export/CSV/CSVExporter.php
@@ -56,7 +56,8 @@ class CSVExporter extends Exporter
         $csvString = $this->serializeItems($items, $start, $count, $total);
         $targetPath = sprintf('%s/findologic.csv', $targetDirectory);
 
-        // Clear CSV contents if a new export starts with start 0. Otherwise append the contents.
+        // Clear CSV contents if a new export starts. Don't do this for further pagination steps, to prevent
+        // overriding the file itself, causing it to clear all contents except the new items.
         file_put_contents($targetPath, $csvString, $start > 0 ? FILE_APPEND : 0);
 
         return $targetPath;

--- a/tests/FINDOLOGIC/Export/Tests/CSVSerializationTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/CSVSerializationTest.php
@@ -147,6 +147,32 @@ class CSVSerializationTest extends TestCase
         $this->assertCount(3, file(self::CSV_PATH));
     }
 
+    public function testCsvWillNotOverrideItselfWhenPassingACountHigherThenZero(): void
+    {
+        $item = $this->getMinimalItem();
+        $expectedInitialData = 'This is some pretty nice data.';
+        $expectedCsvContent = $this->exporter->serializeItems([$item], 1, 1, 1);
+
+        file_put_contents(self::CSV_PATH, $expectedInitialData);
+        $this->exporter->serializeItemsToFile('/tmp', [$item], 1, 1, 1);
+
+        $actualContents = file_get_contents(self::CSV_PATH);
+        $this->assertStringStartsWith($expectedInitialData, $actualContents);
+        $this->assertStringEndsWith($expectedCsvContent, $actualContents);
+    }
+
+    public function testCsvWillOverrideItselfWhenPassingAnInitialCount(): void
+    {
+        $item = $this->getMinimalItem();
+        $expectedCsvContent = $this->exporter->serializeItems([$item], 0, 1, 1);
+
+        file_put_contents(self::CSV_PATH, 'This is some pretty nice data.');
+        $this->exporter->serializeItemsToFile('/tmp', [$item], 0, 1, 1);
+
+        $this->assertEquals($expectedCsvContent, file_get_contents(self::CSV_PATH));
+        $this->assertCount(2, file(self::CSV_PATH));
+    }
+
     public function testKitchenSink(): void
     {
         $expectedId = '123';

--- a/tests/FINDOLOGIC/Export/Tests/CSVSerializationTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/CSVSerializationTest.php
@@ -35,6 +35,8 @@ class CSVSerializationTest extends TestCase
     private const DEFAULT_CSV_HEADING = "id\tordernumber\tname\tsummary\tdescription\tprice\tinstead\tmaxprice\t" .
         "taxrate\turl\timage\tattributes\tkeywords\tgroups\tbonus\tsales_frequency\tdate_added\tsort";
 
+    private const CSV_PATH = '/tmp/findologic.csv';
+
     /** @var CSVExporter */
     private $exporter;
 
@@ -48,10 +50,9 @@ class CSVSerializationTest extends TestCase
 
     public function tearDown(): void
     {
-        try {
-            unlink('/tmp/findologic.csv');
-        } catch (Exception $e) {
-            // No need to delete a written file if the test didn't write it.
+        if (file_exists(self::CSV_PATH)) {
+            // Cleanup file after tests have created it.
+            unlink(self::CSV_PATH);
         }
     }
 
@@ -126,11 +127,24 @@ class CSVSerializationTest extends TestCase
     public function testCsvCanBeWrittenDirectlyToFile(): void
     {
         $item = $this->getMinimalItem();
-
         $expectedCsvContent = $this->exporter->serializeItems([$item], 0, 1, 1);
+
         $this->exporter->serializeItemsToFile('/tmp', [$item], 0, 1, 1);
 
-        self::assertEquals($expectedCsvContent, file_get_contents('/tmp/findologic.csv'));
+        $this->assertEquals($expectedCsvContent, file_get_contents(self::CSV_PATH));
+        $this->assertCount(2, file(self::CSV_PATH));
+    }
+
+    public function testCsvWillNotOverrideItselfWhenHavingMultipleSteps(): void
+    {
+        $item = $this->getMinimalItem();
+        $expectedCsvContent = $this->exporter->serializeItems([$item, $item], 0, 2, 2);
+
+        $this->exporter->serializeItemsToFile('/tmp', [$item], 0, 1, 2);
+        $this->exporter->serializeItemsToFile('/tmp', [$item], 1, 1, 2);
+
+        $this->assertEquals($expectedCsvContent, file_get_contents(self::CSV_PATH));
+        $this->assertCount(3, file(self::CSV_PATH));
     }
 
     public function testKitchenSink(): void


### PR DESCRIPTION
## Purpose

There is a flaw in pagination for CSV file pagination. The file is always cleared after calling `serializeItemsToFile`, this makes the pagination completely useless.

Fun fact:

Calling the pagination with start 1 caused the CSV to be completely invalid, as the header is only written if the count is > 0 :laughing: 

## Approach

In `\FINDOLOGIC\Export\CSV\CSVExporter::serializeItemsToFile` when calling `file_put_contents` add the flag `FILE_APPEND`. [PHP documentation](https://www.php.net/manual/en/function.file-put-contents.php):

> If file filename already exists, append the data to the file instead of overwriting it.


#### Open Questions and Pre-Merge TODOs

- [x] `composer lint` and `composer fix` was executed.
- [x] Tests were written and pass with 100% coverage.
- [ ] ~~A issue with a detailed explanation of the problem/enhancement was created and linked.~~
