### PR TITLE
Fix CSV serialization

### DIFF
--- a/src/FINDOLOGIC/Export/CSV/CSVItem.php
+++ b/src/FINDOLOGIC/Export/CSV/CSVItem.php
@@ -137,8 +137,6 @@ class CSVItem extends Item
             $input = strip_tags($input);
         }
 
-        $sanitized = preg_replace('/[\t\n]/', ' ', $input);
-
-        return $sanitized;
+        return preg_replace('/[\t\n\r]/', ' ', $input);
     }
 }

--- a/tests/FINDOLOGIC/Export/Tests/CSVSerializationTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/CSVSerializationTest.php
@@ -417,5 +417,6 @@ class CSVSerializationTest extends TestCase
 
         $this->assertEquals(1, preg_match_all('/\n/', $csvLine));
         $this->assertEquals(17, preg_match_all('/\t/', $csvLine));
+        $this->assertEquals(0, preg_match_all('/\r/', $csvLine));
     }
 }


### PR DESCRIPTION
## Purpose

The generated CSV is broken when a `\r` character is used.

## Approach

Serialize `\r` characters like `\n` and `\t`.

#### Open Questions and Pre-Merge TODOs

- [x] `composer lint` and `composer fix` was executed.
- [x] Tests were written and pass with 100% coverage.
- [ ] ~~A issue with a detailed explanation of the problem/enhancement was created and linked.~~
