### PR TITLE
Support PHP 8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         extensions: mbstring, dom
         coverage: xdebug
-        tools: composer
+        tools: composer:v2
 
     - name: Cache dependencies
       uses: actions/cache@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.1', '7.2', '7.3', '7.4']
-    name: PHP ${{ matrix.php-versions }} Test
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0']
+    name: PHP ${{ matrix.php }} Test
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -16,16 +16,10 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: ${{ matrix.php-versions }}
+        php-version: ${{ matrix.php }}
         extensions: mbstring, dom
         coverage: xdebug
         tools: composer:v2
-
-    - name: Cache dependencies
-      uses: actions/cache@v1
-      with:
-        path: ~/.composer/cache/files
-        key: cache-php-${{ matrix.php-versions }}-composer-${{ hashFiles('composer.json') }}
 
     - name: Run test suite
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,25 +3,30 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         php: ['7.1', '7.2', '7.3', '7.4', '8.0']
-    name: PHP ${{ matrix.php }} Test
+        stability: [prefer-lowest, prefer-stable]
+
+    name: PHP ${{ matrix.php }} - ${{ matrix.stability }} Test
+
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php }}
-        extensions: mbstring, dom
-        coverage: xdebug
-        tools: composer:v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, dom
+          coverage: xdebug
+          tools: composer:v2
 
-    - name: Run test suite
-      run: |
-        composer install
-        composer test
+      - name: Install dependencies
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+
+      - name: Run test suite
+        run: composer test

--- a/.github/workflows/test_with_coverage.yml
+++ b/.github/workflows/test_with_coverage.yml
@@ -22,7 +22,7 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         extensions: mbstring, dom
         coverage: xdebug
-        tools: composer
+        tools: composer:v2
 
     - name: Cache dependencies
       uses: actions/cache@v1

--- a/.github/workflows/test_with_coverage.yml
+++ b/.github/workflows/test_with_coverage.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.1', '7.2', '7.3', '7.4']
-    name: PHP ${{ matrix.php-versions }} Test
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0']
+    name: PHP ${{ matrix.php }} Test
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -19,16 +19,10 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: ${{ matrix.php-versions }}
+        php-version: ${{ matrix.php }}
         extensions: mbstring, dom
         coverage: xdebug
         tools: composer:v2
-
-    - name: Cache dependencies
-      uses: actions/cache@v1
-      with:
-        path: ~/.composer/cache/files
-        key: cache-php-${{ matrix.php-versions }}-composer-${{ hashFiles('composer.json') }}
 
     - name: Run test suite
       run: |

--- a/.github/workflows/test_with_coverage.yml
+++ b/.github/workflows/test_with_coverage.yml
@@ -6,34 +6,39 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         php: ['7.1', '7.2', '7.3', '7.4', '8.0']
-    name: PHP ${{ matrix.php }} Test
+        stability: [prefer-lowest, prefer-stable]
+
+    name: PHP ${{ matrix.php }} - ${{ matrix.stability }} Test
+
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php }}
-        extensions: mbstring, dom
-        coverage: xdebug
-        tools: composer:v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, dom
+          coverage: xdebug
+          tools: composer:v2
 
-    - name: Run test suite
-      run: |
-        composer install
-        composer test
+      - name: Install dependencies
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-umbrella
-        fail_ci_if_error: true
+      - name: Run test suite
+        run: composer test
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: true

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "FINDOLOGIC export toolkit for XML and CSV data export",
     "homepage": "https://github.com/findologic/libflexport",
     "require": {
-        "php": "^7.1",
+        "php": "^7.1|^8.0",
         "ext-dom": "*",
         "ext-mbstring": "*",
         "findologic/xml-export-schema": "^1.4"
@@ -54,5 +54,6 @@
         "psr-0": {
             "FINDOLOGIC\\Export\\Tests\\": "tests/"
         }
-    }
+    },
+    "prefer-stable": true
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
-        backupGlobals="false"
+        xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
         colors="true"
         bootstrap="vendor/autoload.php"
 >
@@ -20,7 +18,7 @@
     </filter>
 
     <logging>
-        <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
+        <log type="coverage-text" target="php://stdout"/>
         <log type="coverage-clover" target="./coverage.xml"/>
     </logging>
 </phpunit>

--- a/tests/FINDOLOGIC/Export/Tests/CSVSerializationTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/CSVSerializationTest.php
@@ -28,7 +28,6 @@ use FINDOLOGIC\Export\Exporter;
 use FINDOLOGIC\Export\Helpers\UsergroupAwareMultiValueItem;
 use FINDOLOGIC\Export\Helpers\UsergroupAwareSimpleValue;
 use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
 
 class CSVSerializationTest extends TestCase
 {

--- a/tests/FINDOLOGIC/Export/Tests/DataElementsTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/DataElementsTest.php
@@ -24,7 +24,6 @@ use FINDOLOGIC\Export\Exceptions\ValueIsNotIntegerException;
 use FINDOLOGIC\Export\Exceptions\ValueIsNotNumericException;
 use FINDOLOGIC\Export\Exceptions\ValueIsNotPositiveIntegerException;
 use FINDOLOGIC\Export\Helpers\UsergroupAwareSimpleValue;
-use PHPUnit\Framework\TestCase;
 
 class DataElementsTest extends TestCase
 {

--- a/tests/FINDOLOGIC/Export/Tests/DataHelperTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/DataHelperTest.php
@@ -28,7 +28,6 @@ use FINDOLOGIC\Export\Exceptions\ItemIdLengthException;
 use FINDOLOGIC\Export\Exceptions\ValueIsNotNumericException;
 use FINDOLOGIC\Export\Helpers\DataHelper;
 use FINDOLOGIC\Export\Helpers\NameAwareValue;
-use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionException;
 

--- a/tests/FINDOLOGIC/Export/Tests/ExporterTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/ExporterTest.php
@@ -4,7 +4,6 @@ namespace FINDOLOGIC\Export\Tests;
 
 use FINDOLOGIC\Export\Exporter;
 use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
 
 class ExporterTest extends TestCase
 {

--- a/tests/FINDOLOGIC/Export/Tests/ItemTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/ItemTest.php
@@ -9,7 +9,6 @@ use FINDOLOGIC\Export\Data\Price;
 use FINDOLOGIC\Export\Data\Property;
 use FINDOLOGIC\Export\Exporter;
 use FINDOLOGIC\Export\XML\XMLExporter;
-use PHPUnit\Framework\TestCase;
 
 class ItemTest extends TestCase
 {

--- a/tests/FINDOLOGIC/Export/Tests/PropertyTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/PropertyTest.php
@@ -5,7 +5,6 @@ namespace FINDOLOGIC\Export\Tests;
 use Exception;
 use FINDOLOGIC\Export\Data\Property;
 use FINDOLOGIC\Export\Exceptions\DuplicateValueForUsergroupException;
-use PHPUnit\Framework\TestCase;
 
 class PropertyTest extends TestCase
 {
@@ -59,7 +58,7 @@ class PropertyTest extends TestCase
                 $this->assertNotNull($property);
             }
         } catch (Exception $exception) {
-            $this->assertRegExp('/' . $key . '/', $exception->getMessage());
+            $this->assertMatchesRegularExpression('/' . $key . '/', $exception->getMessage());
         }
     }
 

--- a/tests/FINDOLOGIC/Export/Tests/TestCase.php
+++ b/tests/FINDOLOGIC/Export/Tests/TestCase.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace FINDOLOGIC\Export\Tests;
+
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
+{
+  public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+  {
+      if (method_exists(BaseTestCase::class, 'assertMatchesRegularExpression')) {
+          parent::assertMatchesRegularExpression($pattern, $string, $message);
+      } else {
+          parent::assertRegExp($pattern, $string, $message);
+      }
+  }
+}

--- a/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/XmlSerializationTest.php
@@ -32,7 +32,6 @@ use FINDOLOGIC\Export\XML\Page;
 use FINDOLOGIC\Export\XML\XMLExporter;
 use FINDOLOGIC\Export\XML\XMLItem;
 use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**


### PR DESCRIPTION
## Purpose

This PR adds CI tests for PHP 8 and updates the CI workflows.

## Approach

Add PHP 8 to workflow matrix and allow it in the composer file. Also add new phpunit configuration file.

#### Open Questions and Pre-Merge TODOs

- [x] ~~`composer lint` and `composer fix` was executed.~~
- [x] Tests were written and pass with 100% coverage.
- [x] ~~A issue with a detailed explanation of the problem/enhancement was created and linked.~~
