### PR TITLE
Allow getting price if no price is assigned yet

### DIFF
--- a/src/FINDOLOGIC/Export/Data/Item.php
+++ b/src/FINDOLOGIC/Export/Data/Item.php
@@ -23,7 +23,7 @@ abstract class Item implements Serializable
     /** @var Description */
     protected $description;
 
-    /** @var Price */
+    /** @var Price|null */
     protected $price;
 
     /** @var float */
@@ -169,7 +169,7 @@ abstract class Item implements Serializable
         $this->description->setValue($description, $usergroup);
     }
 
-    public function getPrice(): Price
+    public function getPrice(): ?Price
     {
         return $this->price;
     }

--- a/tests/FINDOLOGIC/Export/Tests/ItemTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/ItemTest.php
@@ -71,4 +71,11 @@ class ItemTest extends TestCase
         $property = new Property('empty property', []);
         $item->addProperty($property);
     }
+
+    public function testCanAccessPriceIfNotSet(): void
+    {
+        $item = $this->exporter->createItem('123');
+
+        $this->assertNull($item->getPrice());
+    }
 }


### PR DESCRIPTION
## Purpose

In case you have variants and each variant can have it's own price, you do not know if the final product has a price. Therefore you may want to call `Item::getPrice`, but you will be greeted with a nice exception, since the getter does not allow nullables.

Code Example:

```php
$item = $this->exporter->createItem('123');

// . . . Some variant logic to get prices . . .

// Let's check if the price is set
if (!$item->getPrice()) {
    // OK, item has no price, lets not export it...
}

// . . .
```

Shows following error:

`Return value of FINDOLOGIC\Export\Data\Item::getPrice() must be an instance of FINDOLOGIC\Export\Data\Price, null returned`

## Approach

Make that getter nullable, so you can check if a price is actually set or not

#### Open Questions and Pre-Merge TODOs

- [x] `composer lint` and `composer fix` was executed.
- [x] Tests were written and pass with 100% coverage.
- [ ] ~~A issue with a detailed explanation of the problem/enhancement was created and linked.~~
