### PR TITLE
Expose DataHelper limit constants

### DIFF
--- a/src/FINDOLOGIC/Export/Helpers/DataHelper.php
+++ b/src/FINDOLOGIC/Export/Helpers/DataHelper.php
@@ -18,25 +18,25 @@ use FINDOLOGIC\Export\Exceptions\ItemIdLengthException;
  */
 class DataHelper
 {
-    /*
+    /**
      * Internal character limit for attribute values.
      */
-    private const ATTRIBUTE_CHARACTER_LIMIT = 16383;
+    public const ATTRIBUTE_CHARACTER_LIMIT = 16383;
 
-    /*
+    /**
      * Internal character limit for item id.
      */
-    private const ITEM_ID_CHARACTER_LIMIT = 255;
+    public const ITEM_ID_CHARACTER_LIMIT = 255;
 
-    /*
+    /**
      * Internal character limit for group names of CSV export.
      */
-    private const CSV_GROUP_CHARACTER_LIMIT = 255;
+    public const CSV_GROUP_CHARACTER_LIMIT = 255;
 
-    /*
+    /**
      * Internal character limit for attribute key names of CSV export.
      */
-    private const CSV_ATTRIBUTE_KEY_CHARACTER_LIMIT = 247;
+    public const CSV_ATTRIBUTE_KEY_CHARACTER_LIMIT = 247;
 
     /**
      * Checks if the provided value is empty.


### PR DESCRIPTION
## Purpose

If I am using this library in my plugin that I am using in multiple shopsystems, I typically have no control over what customers do in their shop. Since there is a strict limit on how many characters an attribute value has you may experience the following error, if a customer has more characters then the limit allows in a single field:

```
FINDOLOGIC\Export\Exceptions\AttributeValueLengthException : Value of attribute "long_value" exceeds the internal character limit of 16383!
```

Now I want to implement a check in my plugin, but I can not, since all constants in `\FINDOLOGIC\Export\Helpers\DataHelper` are basically private. I would either have to hardcode them or create a fork where I explicitly make them public. Both options are bad.

## Approach

Make these constants public.

#### Open Questions and Pre-Merge TODOs

- [x] `composer lint` and `composer fix` was executed.
- [ ] ~~Tests were written and pass with 100% coverage.~~ Only the visibility of constants has been changed.
- [ ] ~~A issue with a detailed explanation of the problem/enhancement was created and linked.~~ Not necessary.
