### PR TITLE
HR-1408_make_reserved_property_validation_more_accurate (FINDO-9622)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }} Test

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "findologic/xml-export-schema": "^1.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5|^8.5|^9.0",
+        "phpunit/phpunit": "^7.5|^8.6|^9.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5|^8.6|^9.0",
-        "squizlabs/php_codesniffer": "^3.5"
+        "squizlabs/php_codesniffer": "^3.5",
+        "nikic/php-parser": "^4.15"
     },
     "scripts": {
         "lint": "phpcs",

--- a/src/FINDOLOGIC/Export/Data/Property.php
+++ b/src/FINDOLOGIC/Export/Data/Property.php
@@ -11,14 +11,14 @@ class Property
     /**
      * Reserved property keys for internal use which would be overwritten when importing
      *
-     * /image\d+/: Image URLs of type default.
-     * /thumbnail\d+/: Image URLs of type thumbnail.
-     * /ordernumber/: The products first exported ordernumber.
+     * - Image URLs of type default.
+     * - Image URLs of type thumbnail.
+     * - The products first exported ordernumber.
      */
     private const RESERVED_PROPERTY_KEYS = [
-        "/image\d+/",
-        "/thumbnail\d+/",
-        "/ordernumber/"
+        "/^image\d+$/",
+        "/^thumbnail\d+$/",
+        "/^ordernumber$/"
     ];
 
     /** @var string */

--- a/tests/FINDOLOGIC/Export/Tests/PropertyTest.php
+++ b/tests/FINDOLOGIC/Export/Tests/PropertyTest.php
@@ -37,7 +37,10 @@ class PropertyTest extends TestCase
             'reserved property "image\d+"' => ['image0', true],
             'reserved property "thumbnail\d+"' => ['thumbnail1', true],
             'reserved property "ordernumber"' => ['ordernumber', true],
-            'non-reserved property key' => ['foobar', false]
+            'non-reserved property key' => ['foobar', false],
+            'non-reserved property key containing "ordernumber"' => ['main_ordernumber', false],
+            'non-reserved property key containing "image0"' => ['main_image0', false],
+            'non-reserved property key containing "thumbnail0"' => ['main_thumbnail0', false],
         ];
     }
 
@@ -58,7 +61,11 @@ class PropertyTest extends TestCase
                 $this->assertNotNull($property);
             }
         } catch (Exception $exception) {
-            $this->assertMatchesRegularExpression('/' . $key . '/', $exception->getMessage());
+            if (!$shouldCauseException) {
+                $this->fail('Using a non-reserved property key should not cause an exception.');
+            } else {
+                $this->assertMatchesRegularExpression('/' . $key . '/', $exception->getMessage());
+            }
         }
     }
 

--- a/tests/FINDOLOGIC/Export/Tests/TestCase.php
+++ b/tests/FINDOLOGIC/Export/Tests/TestCase.php
@@ -6,12 +6,12 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
 {
-  public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
-  {
-      if (method_exists(BaseTestCase::class, 'assertMatchesRegularExpression')) {
-          parent::assertMatchesRegularExpression($pattern, $string, $message);
-      } else {
-          parent::assertRegExp($pattern, $string, $message);
-      }
-  }
+    public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+    {
+        if (method_exists(BaseTestCase::class, 'assertMatchesRegularExpression')) {
+            parent::assertMatchesRegularExpression($pattern, $string, $message);
+        } else {
+            parent::assertRegExp($pattern, $string, $message);
+        }
+    }
 }


### PR DESCRIPTION
## Purpose

Property validation appears to be triggered by using property names containing a reserved property name. Only property names that match reserved property names exactly should be blocked.

## Approach

Make the regular expression for validating property names more accurate.

#### Open Questions and Pre-Merge TODOs

- [x] `composer lint` and `composer fix` was executed.
- [x] Tests were written and pass with 100% coverage.
- [x] A issue with a detailed explanation of the problem/enhancement was created and linked.
